### PR TITLE
Fix error in formulation of eq. 15.5.

### DIFF
--- a/src/models/generator_models/shaft_models.jl
+++ b/src/models/generator_models/shaft_models.jl
@@ -32,7 +32,7 @@ function mdl_shaft_ode!(
 
     #Compute 2 states ODEs
     output_ode[local_ix[1]] = 2 * π * f0 * (ω - ω_sys)                    #15.5
-    output_ode[local_ix[2]] = (1 / (2 * H)) * (τm - τe - D * (ω - 1.0) / ω)   #15.5
+    output_ode[local_ix[2]] = (1 / (2 * H)) * (τm - τe - D * (ω - ω_sys))   #15.5
 
     return
 end


### PR DESCRIPTION
In the book  _Power System Modelling and Scripting(2010)_ eq.15.5.2 is formulated as ...D(ω-ω_s) similar to eq.15.5.1.  This formulation is also applied in page 244, taking  ω_s to be 1. Here _delta_ formulation is also in agreement with the _omega_ formulation. This is different with the current state of the code which uses;
`D * (ω - 1.0) / ω` instead of `D * (ω - ω_s)`.