### PR TITLE
add ext to StaticWrapper

### DIFF
--- a/src/base/device_wrapper.jl
+++ b/src/base/device_wrapper.jl
@@ -366,6 +366,7 @@ struct StaticWrapper{T <: PSY.StaticInjection, V}
     P_ref::Base.RefValue{Float64}
     Q_ref::Base.RefValue{Float64}
     bus_ix::Int
+    ext::Dict{String, Any}
 end
 
 function DynamicWrapper(device::T, bus_ix::Int) where {T <: PSY.Device}
@@ -378,6 +379,7 @@ function DynamicWrapper(device::T, bus_ix::Int) where {T <: PSY.Device}
         Base.Ref(PSY.get_active_power(device)),
         Base.Ref(PSY.get_reactive_power(device)),
         bus_ix,
+        Dict{String, Any}(),
     )
 end
 
@@ -391,6 +393,7 @@ function StaticWrapper(device::T, bus_ix::Int) where {T <: PSY.Source}
         Base.Ref(PSY.get_active_power(device)),
         Base.Ref(PSY.get_reactive_power(device)),
         bus_ix,
+        Dict{String, Any}(),
     )
 end
 
@@ -400,6 +403,7 @@ get_bus_category(::StaticWrapper{<:PSY.StaticInjection, U}) where {U} = U
 # TODO: something smart to forward fields
 get_device(wrapper::StaticWrapper) = wrapper.device
 get_bus_ix(wrapper::StaticWrapper) = wrapper.bus_ix
+get_ext(wrapper::StaticWrapper) = wrapper.ext
 
 get_P_ref(wrapper::StaticWrapper) = wrapper.P_ref[]
 get_Q_ref(wrapper::StaticWrapper) = wrapper.Q_ref[]

--- a/src/base/simulation.jl
+++ b/src/base/simulation.jl
@@ -301,7 +301,7 @@ function _build_perturbations!(sim::Simulation)
     perturbations = sim.perturbations
     perturbations_count = length(perturbations)
     callback_vector = Vector{SciMLBase.DiscreteCallback}(undef, perturbations_count)
-    tstops = Float64[] 
+    tstops = Float64[]
     for (ix, pert) in enumerate(perturbations)
         _add_callback!(tstops, callback_vector, ix, pert, sim, inputs)
     end
@@ -310,13 +310,20 @@ function _build_perturbations!(sim::Simulation)
     return
 end
 
-function _add_callback!(tstops::Vector{Float64}, callback_vector:: Vector{SciMLBase.DiscreteCallback}, ix::Int, pert::T, sim::Simulation, inputs::SimulationInputs) where {T <: Perturbation}
+function _add_callback!(
+    tstops::Vector{Float64},
+    callback_vector::Vector{SciMLBase.DiscreteCallback},
+    ix::Int,
+    pert::T,
+    sim::Simulation,
+    inputs::SimulationInputs,
+) where {T <: Perturbation}
     @debug pert
     condition = (x, t, integrator) -> t in [pert.time]
     affect = get_affect(inputs, get_system(sim), pert)
     callback_vector[ix] = SciMLBase.DiscreteCallback(condition, affect)
     push!(tstops, pert.time)
-end 
+end
 
 function _get_diffeq_problem(
     sim::Simulation,

--- a/src/base/simulation.jl
+++ b/src/base/simulation.jl
@@ -323,6 +323,7 @@ function _add_callback!(
     affect = get_affect(inputs, get_system(sim), pert)
     callback_vector[ix] = SciMLBase.DiscreteCallback(condition, affect)
     push!(tstops, pert.time)
+    return
 end
 
 function _get_diffeq_problem(

--- a/src/initialization/generator_components/init_tg.jl
+++ b/src/initialization/generator_components/init_tg.jl
@@ -8,7 +8,7 @@ function initialize_tg!(
     τm0 = inner_vars[τm_var]
     eff = PSY.get_efficiency(tg)
     P_ref = τm0 / eff
-    #PSY.set_P_ref!(tg, P_ref)
+    PSY.set_P_ref!(tg, P_ref)
     #Update Control Refs
     set_P_ref(dynamic_device, P_ref)
     return


### PR DESCRIPTION
Adds an ext field to StaticWrapper. The reason for this change is to allow for implementing new surrogate models which are `<:StaticInjection` with minimal changes to PSID.  Also creates a function  `_add_callback!` to allow for handling different types of perturbations when building the callback vector. In my case this allows me to define a perturbation which is essentially just for saving values during the simulation. 