### PR TITLE
fix basepower scaling in loads

### DIFF
--- a/src/base/device_wrapper.jl
+++ b/src/base/device_wrapper.jl
@@ -443,7 +443,7 @@ function StaticLoadWrapper(
     bus::PSY.Bus,
     loads::Vector{PSY.ElectricLoad},
     bus_ix::Int,
-    sys_base_power,
+    sys_base_power::Float64,
 )
     P_power = 0.0
     P_current = 0.0
@@ -454,20 +454,19 @@ function StaticLoadWrapper(
 
     # Add ZIP Loads
     for ld in loads
+        base_power_conversion = PSY.get_base_power(ld) / sys_base_power
         if isa(ld, PSY.PowerLoad)
             base_power = PSY.get_base_power(ld)
-            P_power += PSY.get_active_power(ld) * (base_power / sys_base_power)
-            Q_power += PSY.get_reactive_power(ld) * (base_power / sys_base_power)
+            P_power += PSY.get_active_power(ld) * base_power_conversion
+            Q_power += PSY.get_reactive_power(ld) * base_power_conversion
         elseif isa(ld, PSY.StandardLoad)
             base_power = PSY.get_base_power(ld)
-            P_impedance +=
-                PSY.get_impedance_active_power(ld) * (base_power / sys_base_power)
-            Q_impedance +=
-                PSY.get_impedance_reactive_power(ld) * (base_power / sys_base_power)
-            P_current += PSY.get_current_active_power(ld) * (base_power / sys_base_power)
-            Q_current += PSY.get_current_reactive_power(ld) * (base_power / sys_base_power)
-            P_power += PSY.get_constant_active_power(ld) * (base_power / sys_base_power)
-            Q_power += PSY.get_constant_reactive_power(ld) * (base_power / sys_base_power)
+            P_impedance += PSY.get_impedance_active_power(ld) * base_power_conversion
+            Q_impedance += PSY.get_impedance_reactive_power(ld) * base_power_conversion
+            P_current += PSY.get_current_active_power(ld) * base_power_conversion
+            Q_current += PSY.get_current_reactive_power(ld) * base_power_conversion
+            P_power += PSY.get_constant_active_power(ld) * base_power_conversion
+            Q_power += PSY.get_constant_reactive_power(ld) * base_power_conversion
         end
     end
 
@@ -477,13 +476,13 @@ function StaticLoadWrapper(
     dict_names = Dict{String, Int}()
     if !isempty(exp_loads)
         for (ix, ld) in enumerate(exp_loads)
-            base_power = PSY.get_base_power(ld)
+            base_power_conversion = PSY.get_base_power(ld) / sys_base_power
             dict_names[PSY.get_name(ld)] = ix
             exp_params[ix] = ExpLoadParams(
-                PSY.get_active_power(ld) * (base_power / sys_base_power),
+                PSY.get_active_power(ld) * base_power_conversion,
                 PSY.get_active_power_coefficient(ld),
-                PSY.get_reactive_power(ld),
-                PSY.get_reactive_power_coefficient(ld) * (base_power / sys_base_power),
+                PSY.get_reactive_power(ld) * base_power_conversion,
+                PSY.get_reactive_power_coefficient(ld),
             )
         end
     end

--- a/src/base/device_wrapper.jl
+++ b/src/base/device_wrapper.jl
@@ -456,11 +456,9 @@ function StaticLoadWrapper(
     for ld in loads
         base_power_conversion = PSY.get_base_power(ld) / sys_base_power
         if isa(ld, PSY.PowerLoad)
-            base_power = PSY.get_base_power(ld)
             P_power += PSY.get_active_power(ld) * base_power_conversion
             Q_power += PSY.get_reactive_power(ld) * base_power_conversion
         elseif isa(ld, PSY.StandardLoad)
-            base_power = PSY.get_base_power(ld)
             P_impedance += PSY.get_impedance_active_power(ld) * base_power_conversion
             Q_impedance += PSY.get_impedance_reactive_power(ld) * base_power_conversion
             P_current += PSY.get_current_active_power(ld) * base_power_conversion

--- a/src/base/perturbations.jl
+++ b/src/base/perturbations.jl
@@ -617,7 +617,8 @@ function _find_device_index(inputs::SimulationInputs, device::PSY.ElectricLoad)
     return wrapped_device_ixs[1]
 end
 
-function get_affect(inputs::SimulationInputs, ::PSY.System, pert::LoadChange)
+function get_affect(inputs::SimulationInputs, sys::PSY.System, pert::LoadChange)
+    sys_base_power = PSY.get_base_power(sys)
     wrapped_device_ix = _find_zip_load_ix(inputs, pert.device)
     ld = pert.device
     if !PSY.get_available(ld)
@@ -628,14 +629,15 @@ function get_affect(inputs::SimulationInputs, ::PSY.System, pert::LoadChange)
     signal = pert.signal
     if isa(ld, PSY.PowerLoad)
         return (integrator) -> begin
+            base_power_conversion = PSY.get_base_power(ld) / sys_base_power
             P_old = PSY.get_active_power(ld)
             Q_old = PSY.get_reactive_power(ld)
             P_change = 0.0
             Q_change = 0.0
             if signal ∈ [:P_ref, :P_ref_power]
-                P_change = ref_value - P_old
+                P_change = (ref_value - P_old) * base_power_conversion
             elseif signal ∈ [:Q_ref, :Q_ref_power]
-                Q_change = ref_value - Q_old
+                Q_change = ref_value - Q_old * base_power_conversion
             else
                 error(
                     "Signal is not accepted for Constant PowerLoad. Please specify the correct signal type.",
@@ -651,36 +653,37 @@ function get_affect(inputs::SimulationInputs, ::PSY.System, pert::LoadChange)
         end
     elseif isa(ld, PSY.StandardLoad)
         return (integrator) -> begin
+            base_power_conversion = PSY.get_base_power(ld) / sys_base_power
             wrapped_zip = get_static_loads(integrator.p)[wrapped_device_ix]
             # List all cases for StandardLoad changes
             if signal ∈ [:P_ref, :P_ref_impedance]
                 P_old = PSY.get_impedance_active_power(ld)
-                P_change = ref_value - P_old
+                P_change = (ref_value - P_old) * base_power_conversion
                 P_impedance = get_P_impedance(wrapped_zip)
                 set_P_impedance!(wrapped_zip, P_impedance + P_change)
             elseif signal ∈ [:Q_ref, :Q_ref_impedance]
                 Q_old = PSY.get_impedance_reactive_power(ld)
-                Q_change = ref_value - Q_old
+                Q_change = (ref_value - Q_old) * base_power_conversion
                 Q_impedance = get_Q_impedance(wrapped_zip)
                 set_Q_impedance!(wrapped_zip, Q_impedance + Q_change)
             elseif signal == :P_ref_power
                 P_old = PSY.get_constant_active_power(ld)
-                P_change = ref_value - P_old
+                P_change = (ref_value - P_old) * base_power_conversion
                 P_power = get_P_power(wrapped_zip)
                 set_P_power!(wrapped_zip, P_power + P_change)
             elseif signal == :Q_ref_power
                 Q_old = PSY.get_constant_reactive_power(ld)
-                Q_change = ref_value - Q_old
+                Q_change = (ref_value - Q_old) * base_power_conversion
                 Q_power = get_Q_power(wrapped_zip)
                 set_Q_power!(wrapped_zip, Q_power + Q_change)
             elseif signal == :P_ref_current
                 P_old = PSY.get_current_active_power(ld)
-                P_change = ref_value - P_old
+                P_change = (ref_value - P_old) * base_power_conversion
                 P_current = get_P_current(wrapped_zip)
                 set_P_current!(wrapped_zip, P_current + P_change)
             elseif signal == :Q_ref_current
                 Q_old = PSY.get_current_reactive_power(ld)
-                Q_change = ref_value - Q_old
+                Q_change = (ref_value - Q_old) * base_power_conversion
                 Q_current = get_Q_current(wrapped_zip)
                 set_Q_current!(wrapped_zip, Q_current + Q_change)
             else
@@ -728,7 +731,8 @@ mutable struct LoadTrip <: Perturbation
     device::PSY.ElectricLoad
 end
 
-function get_affect(inputs::SimulationInputs, ::PSY.System, pert::LoadTrip)
+function get_affect(inputs::SimulationInputs, sys::PSY.System, pert::LoadTrip)
+    sys_base_power = PSY.get_base_power(sys)
     wrapped_device_ix = _find_zip_load_ix(inputs, pert.device)
     ld = pert.device
     if !PSY.get_available(ld)
@@ -736,8 +740,9 @@ function get_affect(inputs::SimulationInputs, ::PSY.System, pert::LoadTrip)
         return
     end
     if isa(ld, PSY.PowerLoad)
-        P_trip = PSY.get_active_power(ld)
-        Q_trip = PSY.get_reactive_power(ld)
+        base_power_conversion = PSY.get_base_power(ld) / sys_base_power
+        P_trip = PSY.get_active_power(ld) * base_power_conversion
+        Q_trip = PSY.get_reactive_power(ld) * base_power_conversion
         return (integrator) -> begin
             PSY.set_available!(ld, false)
             wrapped_zip = get_static_loads(integrator.p)[wrapped_device_ix]
@@ -749,12 +754,13 @@ function get_affect(inputs::SimulationInputs, ::PSY.System, pert::LoadTrip)
             return
         end
     elseif isa(ld, PSY.StandardLoad)
-        P_power_trip = PSY.get_constant_active_power(ld)
-        Q_power_trip = PSY.get_constant_reactive_power(ld)
-        P_current_trip = PSY.get_current_active_power(ld)
-        Q_current_trip = PSY.get_current_reactive_power(ld)
-        P_impedance_trip = PSY.get_impedance_active_power(ld)
-        Q_impedance_trip = PSY.get_impedance_reactive_power(ld)
+        base_power_conversion = PSY.get_base_power(ld) / sys_base_power
+        P_power_trip = PSY.get_constant_active_power(ld) * base_power_conversion
+        Q_power_trip = PSY.get_constant_reactive_power(ld) * base_power_conversion
+        P_current_trip = PSY.get_current_active_power(ld) * base_power_conversion
+        Q_current_trip = PSY.get_current_reactive_power(ld) * base_power_conversion
+        P_impedance_trip = PSY.get_impedance_active_power(ld) * base_power_conversion
+        Q_impedance_trip = PSY.get_impedance_reactive_power(ld) * base_power_conversion
         return (integrator) -> begin
             PSY.set_available!(ld, false)
             wrapped_zip = get_static_loads(integrator.p)[wrapped_device_ix]

--- a/src/initialization/generator_components/init_tg.jl
+++ b/src/initialization/generator_components/init_tg.jl
@@ -8,7 +8,7 @@ function initialize_tg!(
     τm0 = inner_vars[τm_var]
     eff = PSY.get_efficiency(tg)
     P_ref = τm0 / eff
-    #PSY.set_P_ref!(tg, P_ref)
+    PSY.set_P_ref!(tg, P_ref)
     #Update Control Refs
     set_P_ref(dynamic_device, P_ref)
     return

--- a/test/test_case50_load_basepower.jl
+++ b/test/test_case50_load_basepower.jl
@@ -1,0 +1,103 @@
+"""
+Test basepowers load models:
+Builds a OMIB system with a load. Tests that the active power flow
+across the single branch does not change when the base power of the 
+load is changed. Includes a LoadChange and LoadTrip to ensure that
+base power scaling is handled properly in the perturbation. 
+"""
+
+include(joinpath(TEST_FILES_DIR, "data_tests", "dynamic_test_data.jl"))
+include(joinpath(TEST_FILES_DIR, "data_tests", "data_utils.jl"))
+
+function standard_load(b)
+    return StandardLoad(
+        name = "test-load",
+        available = true,
+        bus = b,
+        base_power = 100.0,
+        constant_active_power = 0.0,
+        constant_reactive_power = 0.0,
+        impedance_active_power = 0.1,
+        impedance_reactive_power = 0.01,
+        current_active_power = 0.0,
+        current_reactive_power = 0.0,
+        max_constant_active_power = 0.0,
+        max_constant_reactive_power = 0.0,
+        max_impedance_active_power = 1.0,
+        max_impedance_reactive_power = 1.0,
+        max_current_active_power = 0.0,
+        max_current_reactive_power = 0.0,
+    )
+end
+
+function dyn_gen_classic(generator)
+    return DynamicGenerator(
+        name = get_name(generator),
+        ω_ref = 1.0,
+        machine = machine_classic(),
+        shaft = shaft_damping(),
+        avr = avr_none(),
+        prime_mover = tg_none(),
+        pss = pss_none(),
+    )
+end
+
+OMIB_dir = joinpath(TEST_FILES_DIR, "data_tests", "OMIB.raw")
+omib_sys = System(OMIB_dir, runchecks = false)
+add_source_to_ref(omib_sys)
+b = get_component(Bus, omib_sys, "BUS 2")
+l = standard_load(b)
+add_component!(omib_sys, l)
+gen = [g for g in get_components(Generator, omib_sys)][1]
+case_gen = dyn_gen_classic(gen)
+add_component!(omib_sys, case_gen, gen)
+
+pert = LoadChange(0.1, l, :P_ref_impedance, 0.3)
+sim = Simulation!(MassMatrixModel, omib_sys, pwd(), (0.0, 1.0), pert)
+execute!(sim, Rodas5())
+results = read_results(sim)
+_, P_refchange_original = get_activepower_branch_flow(results, "BUS 1-BUS 2-i_1", :to)
+
+pert = LoadTrip(0.1, l)
+sim = Simulation!(MassMatrixModel, omib_sys, pwd(), (0.0, 1.0), pert)
+execute!(sim, Rodas5())
+results = read_results(sim)
+_, P_trip_original = get_activepower_branch_flow(results, "BUS 1-BUS 2-i_1", :to)
+
+# Change base power of load, setpoints, and perturbation such that 
+# the result should be identical to the original system. 
+OMIB_dir = joinpath(TEST_FILES_DIR, "data_tests", "OMIB.raw")
+omib_sys = System(OMIB_dir, runchecks = false)
+add_source_to_ref(omib_sys)
+b = get_component(Bus, omib_sys, "BUS 2")
+l = standard_load(b)
+add_component!(omib_sys, l)
+gen = [g for g in get_components(Generator, omib_sys)][1]
+case_gen = dyn_gen_classic(gen)
+add_component!(omib_sys, case_gen, gen)
+
+set_base_power!(l, get_base_power(l) / 2)
+set_impedance_active_power!(l, get_impedance_active_power(l) * 2)
+set_impedance_reactive_power!(l, get_impedance_reactive_power(l) * 2)
+pert = LoadChange(0.1, l, :P_ref_impedance, 0.6)
+
+sim = Simulation!(MassMatrixModel, omib_sys, pwd(), (0.0, 1.0), pert)
+execute!(sim, Rodas5())
+results = read_results(sim)
+_, P_refchange_new = get_activepower_branch_flow(results, "BUS 1-BUS 2-i_1", :to)
+
+pert = LoadTrip(0.1, l)
+sim = Simulation!(MassMatrixModel, omib_sys, pwd(), (0.0, 1.0), pert)
+execute!(sim, Rodas5())
+results = read_results(sim)
+_, P_trip_new = get_activepower_branch_flow(results, "BUS 1-BUS 2-i_1", :to)
+
+#Test starting power is the same
+@test isapprox(P_refchange_original[1], P_refchange_new[1], atol = 1e-10)
+#Test end power is the same after load reference change
+@test isapprox(P_refchange_original[end], P_refchange_new[end], atol = 1e-10)
+
+#Test starting power is the same
+@test isapprox(P_trip_original[1], P_trip_new[1], atol = 1e-10)
+#Test end power is the same after load trip
+@test isapprox(P_trip_original[end], P_trip_new[end], atol = 1e-10)


### PR DESCRIPTION
- Scales the base power for loads so that the base power of the load can be different than the system base. 
- Test includes a simulation with `LoadTrip `and `LoadChange` to ensure the scaling is handled in the perturbations as well. 