### PR TITLE
Jd/export inner vars

### DIFF
--- a/src/base/simulation_inputs.jl
+++ b/src/base/simulation_inputs.jl
@@ -17,6 +17,7 @@ struct SimulationInputs
     mass_matrix::LinearAlgebra.Diagonal{Float64}
     global_vars_update_pointers::Dict{Int, Int}
     global_state_map::MAPPING_DICT
+    global_inner_var_map::Dict{String, Dict}
 
     function SimulationInputs(
         sys::PSY.System,
@@ -89,6 +90,7 @@ struct SimulationInputs
             mass_matrix,
             global_vars,
             MAPPING_DICT(),
+            Dict{String, Dict}()
         )
     end
 end

--- a/src/base/simulation_inputs.jl
+++ b/src/base/simulation_inputs.jl
@@ -90,7 +90,7 @@ struct SimulationInputs
             mass_matrix,
             global_vars,
             MAPPING_DICT(),
-            Dict{String, Dict}()
+            Dict{String, Dict}(),
         )
     end
 end

--- a/src/post_processing/post_proc_common.jl
+++ b/src/post_processing/post_proc_common.jl
@@ -23,6 +23,27 @@ function make_global_state_map(inputs::SimulationInputs)
     return dic
 end
 
+function _get_inner_vars_map(wrapper::DynamicWrapper{T}) where {T <: PSY.DynamicGenerator}
+    index = get_inner_vars_index(wrapper)
+    inner_vars_enums = instances(generator_inner_vars)
+    return Dict(inner_vars_enums .=> index)
+end
+
+function _get_inner_vars_map(wrapper::DynamicWrapper{T}) where {T <: PSY.DynamicInverter}
+    index = get_inner_vars_index(wrapper)
+    inner_vars_enums = instances(inverter_inner_vars)
+    return Dict(inner_vars_enums .=> index)
+end
+
+function make_inner_vars_map(inputs::SimulationInputs)
+    map = inputs.global_inner_var_map
+    device_wrappers = get_dynamic_injectors(inputs)
+    for d in device_wrappers
+        map[PSY.get_name(d.device)] = _get_inner_vars_map(d)
+    end
+    return map
+end
+
 function get_state_from_ix(global_index::MAPPING_DICT, idx::Int)
     for (name, device_ix) in global_index
         if idx ∈ values(device_ix)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Revise
+
 using PowerSimulationsDynamics
 using PowerSystems
 using Test


### PR DESCRIPTION
@m-bossart use this function to export the initial inner vars 


```Julia
function export_inner_vars(sim)
    inner_vars = sim.problem.f.f.cache.inner_vars
    iv_map = PSID.make_inner_vars_map(sim.inputs)
    output_map = Dict()
    for (k, d_map) in iv_map
        output_map[k] = Dict()
        for (state, ix) in d_map
            output_map[k][state] = inner_vars[ix]
        end
    end
    return output_map
end
```