### PR TITLE
restore RNG state after generating random numbers

### DIFF
--- a/src/base/jacobian.jl
+++ b/src/base/jacobian.jl
@@ -71,7 +71,9 @@ function JacobianFunctionWrapper(
     if sparse_retrieve_loop > 0
         for _ in 1:sparse_retrieve_loop
             temp = zeros(n, n)
+            rng_state = copy(Random.default_rng())
             Jf(temp, x0 + Random.randn(n))
+            copy!(Random.default_rng(), rng_state)
             jac .+= abs.(temp)
         end
         Jv = SparseArrays.sparse(jac)
@@ -104,7 +106,9 @@ function JacobianFunctionWrapper(
     if sparse_retrieve_loop > 0
         for _ in 1:sparse_retrieve_loop
             temp = zeros(n, n)
+            rng_state = copy(Random.default_rng())
             Jf(temp, x0 + Random.randn(n))
+            copy!(Random.default_rng(), rng_state)
             jac .+= abs.(temp)
         end
         Jv = SparseArrays.sparse(jac .+ mass_matrix)


### PR DESCRIPTION
For generating datasets from PSID simulations it is useful to rely on a seed and random number generator to randomly select a perturbation. Currently, it is not possible to evaluate the same set of randomly selected perturbations for systems of different size (# of states) because of the call to the random number generator within a PSID simulation. This PR will reset the state of the random number generator so the state is not changed during a simulation. 