### PR TITLE
Access solution at arbitrary vector of times

### DIFF
--- a/src/post_processing/post_proc_generator.jl
+++ b/src/post_processing/post_proc_generator.jl
@@ -8,7 +8,7 @@ function compute_output_current(
     dynamic_device::I,
     ::Vector{Float64},
     ::Vector{Float64},
-    ::Union{Nothing, Float64},
+    ::Union{Nothing, Float64, Vector{Float64}},
 ) where {I <: PSY.DynamicInjection}
 
     #Return error
@@ -27,7 +27,7 @@ function compute_output_current(
     dynamic_device::G,
     V_R::Vector{Float64},
     V_I::Vector{Float64},
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {G <: PSY.DynamicGenerator}
 
     #Obtain Data
@@ -59,7 +59,7 @@ function compute_output_current(
     dynamic_device::PSY.AggregateDistributedGenerationA,
     V_R::Vector{Float64},
     V_I::Vector{Float64},
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
 
     #Obtain Data
@@ -152,7 +152,7 @@ function compute_field_current(
     dynamic_device::G,
     V_R::Vector{Float64},
     V_I::Vector{Float64},
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {G <: PSY.DynamicGenerator}
 
     #Obtain Data
@@ -171,7 +171,7 @@ the dynamic device and bus voltage. It is dispatched for device type to compute 
 function compute_field_voltage(
     res::SimulationResults,
     dynamic_device::G,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {G <: PSY.DynamicGenerator}
 
     #Get AVR
@@ -187,7 +187,7 @@ the dynamic device and bus voltage. It is dispatched for device type to compute 
 function compute_pss_output(
     res::SimulationResults,
     dynamic_device::G,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {G <: PSY.DynamicGenerator}
 
     #Get PSS
@@ -203,7 +203,7 @@ the dynamic device and bus voltage. It is dispatched for device type to compute 
 function compute_mechanical_torque(
     res::SimulationResults,
     dynamic_device::G,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {G <: PSY.DynamicGenerator}
 
     #Get TG
@@ -218,7 +218,7 @@ Function to obtain the output frequency time series of a DynamicGenerator
 function compute_frequency(
     res::SimulationResults,
     dyn_device::G,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {G <: PSY.DynamicGenerator}
     name = PSY.get_name(dyn_device)
     ts, ω = post_proc_state_series(res, (name, :ω), dt)
@@ -236,7 +236,7 @@ function _machine_current(
     V_I::Vector{Float64},
     base_power_ratio::Float64,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     ts, δ = post_proc_state_series(res, (name, :δ), dt)
 
@@ -270,7 +270,7 @@ function _machine_current(
     V_I::Vector{Float64},
     base_power_ratio::Float64,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     ts, δ = post_proc_state_series(res, (name, :δ), dt)
     _, eq_p = post_proc_state_series(res, (name, :eq_p), dt)
@@ -308,7 +308,7 @@ function _machine_current(
     V_I::Vector{Float64},
     base_power_ratio::Float64,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     ts, δ = post_proc_state_series(res, (name, :δ), dt)
     _, eq_pp = post_proc_state_series(res, (name, :eq_pp), dt)
@@ -349,7 +349,7 @@ function _machine_current(
     ::Vector{Float64},
     base_power_ratio::Float64,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     ts, δ = post_proc_state_series(res, (name, :δ), dt)
     _, eq_pp = post_proc_state_series(res, (name, :eq_pp), dt)
@@ -387,7 +387,7 @@ function _machine_current(
     ::Vector{Float64},
     base_power_ratio::Float64,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     ts, δ = post_proc_state_series(res, (name, :δ), dt)
     _, eq_p = post_proc_state_series(res, (name, :eq_p), dt)
@@ -429,7 +429,7 @@ function _machine_current(
     V_I::Vector{Float64},
     base_power_ratio::Float64,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     ts, δ = post_proc_state_series(res, (name, :δ), dt)
     _, eq_p = post_proc_state_series(res, (name, :eq_p), dt)
@@ -481,7 +481,7 @@ function _machine_current(
     V_I::Vector{Float64},
     base_power_ratio::Float64,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     ts, δ = post_proc_state_series(res, (name, :δ), dt)
     _, eq_p = post_proc_state_series(res, (name, :eq_p), dt)
@@ -526,7 +526,7 @@ function _field_current(
     V_R::Vector{Float64},
     V_I::Vector{Float64},
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {M <: PSY.Machine}
     @warn("Field current is not supported in the machine type $(M). Returning zeros.")
     ts, _ = post_proc_state_series(res, (name, :δ), dt)
@@ -544,7 +544,7 @@ function _field_current(
     V_R::Vector{Float64},
     V_I::Vector{Float64},
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {M <: Union{PSY.RoundRotorQuadratic, PSY.RoundRotorExponential}}
     ts, δ = post_proc_state_series(res, (name, :δ), dt)
     _, eq_p = post_proc_state_series(res, (name, :eq_p), dt)
@@ -598,7 +598,7 @@ function _field_current(
     V_R::Vector{Float64},
     V_I::Vector{Float64},
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     ts, δ = post_proc_state_series(res, (name, :δ), dt)
     _, eq_p = post_proc_state_series(res, (name, :eq_p), dt)
@@ -645,7 +645,7 @@ function _field_current(
     V_R::Vector{Float64},
     V_I::Vector{Float64},
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     ts, δ = post_proc_state_series(res, (name, :δ), dt)
     _, eq_p = post_proc_state_series(res, (name, :eq_p), dt)
@@ -694,7 +694,7 @@ function _field_voltage(
     ::A,
     name::String,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {A <: PSY.AVR}
     return post_proc_state_series(res, (name, :Vf), dt)
 end
@@ -707,7 +707,7 @@ function _field_voltage(
     avr::PSY.AVRFixed,
     name::String,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     Vf0 = PSY.get_Vf(avr)
     ts, _ = post_proc_state_series(res, (name, :δ), dt)
@@ -723,7 +723,7 @@ function _field_voltage(
     avr::Union{PSY.ESAC1A, PSY.EXAC1},
     name::String,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     ts, Ve = post_proc_state_series(res, (name, :Ve), dt)
     _, Xad_Ifd = post_proc_field_current_series(res, name, dt)
@@ -741,7 +741,7 @@ function _field_voltage(
     avr::PSY.SCRX,
     name::String,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     ts, Vr2 = post_proc_state_series(res, (name, :Vr2), dt)
     _, Ifd = post_proc_field_current_series(res, name, dt)
@@ -777,7 +777,7 @@ function _field_voltage(
     avr::PSY.ESST1A,
     name::String,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     # Obtain state Va
     ts, Va = post_proc_state_series(res, (name, :Va), dt)
@@ -839,7 +839,7 @@ function _pss_output(
     pss::PSY.PSSFixed,
     name::String,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     ts, _ = post_proc_state_series(res, (name, :δ), dt)
     return ts, zeros(length(ts))
@@ -853,7 +853,7 @@ function _pss_output(
     pss::PSY.IEEEST,
     name::String,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     # Obtain states
     ts, x_p2 = post_proc_state_series(res, (name, :x_p2), dt)
@@ -920,7 +920,7 @@ function _mechanical_torque(
     tg::PSY.TGFixed,
     name::String,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     # TODO: This will not plot correctly when changing P_ref in a callback
     ts, _ = _post_proc_state_series(res.solution, 1, dt)
@@ -939,7 +939,7 @@ function _mechanical_torque(
     tg::PSY.TGTypeI,
     name::String,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     # Get params
     Tc = PSY.get_Tc(tg)
@@ -967,7 +967,7 @@ function _mechanical_torque(
     tg::PSY.TGTypeII,
     name::String,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     # TODO: This will not plot correctly when changing P_ref in a callback
     # Get params
@@ -996,7 +996,7 @@ function _mechanical_torque(
     tg::PSY.SteamTurbineGov1,
     name::String,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     # TODO: This will not plot correctly when changing P_ref in a callback
     # Get params
@@ -1031,7 +1031,7 @@ function _mechanical_torque(
     tg::PSY.GasTG,
     name::String,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     # Get params
     D_turb = PSY.get_D_turb(tg)
@@ -1051,7 +1051,7 @@ function _mechanical_torque(
     tg::PSY.HydroTurbineGov,
     name::String,
     res::SimulationResults,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     # Get params
     q_nl = PSY.get_q_nl(tg)

--- a/src/post_processing/post_proc_inverter.jl
+++ b/src/post_processing/post_proc_inverter.jl
@@ -8,7 +8,7 @@ function compute_output_current(
     dynamic_device::G,
     V_R::Vector{Float64},
     V_I::Vector{Float64},
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {G <: PSY.DynamicInverter}
 
     #Obtain Data
@@ -43,7 +43,7 @@ function compute_field_current(
     dynamic_device::G,
     V_R::Vector{Float64},
     V_I::Vector{Float64},
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {G <: PSY.DynamicInverter}
     @warn("Field current does not exist in inverters. Returning zeros.")
     return (nothing, zeros(length(V_R)))
@@ -57,7 +57,7 @@ the dynamic device and bus voltage. It must return nothing since field voltage d
 function compute_field_voltage(
     res::SimulationResults,
     dynamic_device::G,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {G <: PSY.DynamicInverter}
     @warn("Field voltage does not exist in inverters. Returning zeros.")
     _, state = _post_proc_state_series(res.solution, 1, dt)
@@ -72,7 +72,7 @@ the dynamic device and bus voltage. It must return nothing since mechanical torq
 function compute_mechanical_torque(
     res::SimulationResults,
     dynamic_device::G,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {G <: PSY.DynamicInverter}
     @warn("Mechanical torque is not used in inverters. Returning zeros.")
     _, state = _post_proc_state_series(res.solution, 1, dt)
@@ -82,7 +82,7 @@ end
 function compute_frequency(
     res::SimulationResults,
     dyn_device::G,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {G <: PSY.DynamicInverter}
     outer_control = PSY.get_outer_control(dyn_device)
     frequency_estimator = PSY.get_freq_estimator(dyn_device)
@@ -106,7 +106,7 @@ function _frequency(
     name::String,
     res::SimulationResults,
     dynamic_device::G,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {F <: PSY.FrequencyEstimator, G <: PSY.DynamicInverter}
     ts, ω = post_proc_state_series(res, (name, :ω_oc), dt)
     return ts, ω
@@ -122,7 +122,7 @@ function _frequency(
     name::String,
     res::SimulationResults,
     dynamic_device::G,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {F <: PSY.FrequencyEstimator, G <: PSY.DynamicInverter}
     P_ref = PSY.get_P_ref(PSY.get_active_power_control(outer_control))
     ω_ref = PSY.get_ω_ref(dynamic_device)
@@ -145,7 +145,7 @@ function _frequency(
     name::String,
     res::SimulationResults,
     dynamic_device::G,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {F <: PSY.FrequencyEstimator, G <: PSY.DynamicInverter}
     p_ref = PSY.get_P_ref(PSY.get_active_power_control(outer_control))
     q_ref = PSY.get_Q_ref(PSY.get_reactive_power_control(outer_control))
@@ -174,7 +174,7 @@ function _frequency(
     name::String,
     res::SimulationResults,
     dynamic_device::G,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {G <: PSY.DynamicInverter}
     kp_pll = PSY.get_kp_pll(freq_estimator)
     ki_pll = PSY.get_ki_pll(freq_estimator)
@@ -195,7 +195,7 @@ function _frequency(
     name::String,
     res::SimulationResults,
     dynamic_device::G,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {G <: PSY.DynamicInverter}
     kp_pll = PSY.get_kp_pll(freq_estimator)
     ki_pll = PSY.get_ki_pll(freq_estimator)
@@ -208,7 +208,10 @@ function _frequency(
     return ts, ω_pll
 end
 
-function _system_frequency_series(res::SimulationResults, dt::Union{Nothing, Float64})
+function _system_frequency_series(
+    res::SimulationResults,
+    dt::Union{Nothing, Float64, Vector{Float64}},
+)
     if get_global_vars_update_pointers(res)[GLOBAL_VAR_SYS_FREQ_INDEX] == 0
         ω_sys = 1.0
     else
@@ -234,7 +237,7 @@ function _output_current(
     base_power_ratio::Float64,
     res::SimulationResults,
     dynamic_device::G,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {C <: PSY.Converter, G <: PSY.DynamicInverter}
     ts, ir_filter = post_proc_state_series(res, (name, :ir_filter), dt)
     ts, ii_filter = post_proc_state_series(res, (name, :ii_filter), dt)
@@ -255,7 +258,7 @@ function _output_current(
     base_power_ratio::Float64,
     res::SimulationResults,
     ::G,
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 ) where {G <: PSY.DynamicInverter}
 
     #Get Converter parameters

--- a/src/post_processing/post_proc_loads.jl
+++ b/src/post_processing/post_proc_loads.jl
@@ -8,7 +8,7 @@ function compute_output_current(
     dynamic_device::PSY.SingleCageInductionMachine,
     V_R::Vector{Float64},
     V_I::Vector{Float64},
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     #Obtain Data
     sys = get_system(res)
@@ -58,7 +58,7 @@ function compute_output_current(
     dynamic_device::PSY.SimplifiedSingleCageInductionMachine,
     V_R::Vector{Float64},
     V_I::Vector{Float64},
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     #Obtain Data
     sys = get_system(res)
@@ -112,7 +112,7 @@ function compute_output_current(
     device::PSY.PowerLoad,
     V_R::Vector{Float64},
     V_I::Vector{Float64},
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     #TODO: We should dispatch this using the ZipLoad model that we have, but that would
     #      require to properly have access to it in the SimResults.
@@ -152,7 +152,7 @@ function compute_output_current(
     device::PSY.ExponentialLoad,
     V_R::Vector{Float64},
     V_I::Vector{Float64},
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     #TODO: We should dispatch this using the ZipLoad model that we have, but that would
     #      require to properly have access to it in the SimResults.
@@ -193,7 +193,7 @@ function compute_output_current(
     device::PSY.StandardLoad,
     V_R::Vector{Float64},
     V_I::Vector{Float64},
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     #TODO: We should dispatch this using the ZipLoad model that we have, but that would
     #      require to properly have access to it in the SimResults.

--- a/src/post_processing/post_proc_source.jl
+++ b/src/post_processing/post_proc_source.jl
@@ -73,7 +73,7 @@ function compute_output_current(
     dynamic_device::PSY.PeriodicVariableSource,
     V_R::Vector{Float64},
     V_I::Vector{Float64},
-    dt::Union{Nothing, Float64},
+    dt::Union{Nothing, Float64, Vector{Float64}},
 )
     name = PSY.get_name(dynamic_device)
     ts, Vt_internal = post_proc_state_series(res, (name, :Vt), dt)

--- a/test/test_base.jl
+++ b/test/test_base.jl
@@ -743,6 +743,10 @@ end
         t = series[1]
         δ = series[2]
         @test t[2] - t[1] == 0.01
+        series = get_state_series(results, ("generator-102-1", :δ); dt = [0.02, 0.05])
+        t = series[1]
+        δ = series[2]
+        @test t[1] == 0.02
     finally
         @info("removing test files")
         rm(path; force = true, recursive = true)


### PR DESCRIPTION
Expands the interface to allow for passing a vector of times instead of simply a fixed dt or nothing which returns the solution timesteps. 