### PR TITLE
post processing functions return Vector{Float64}

### DIFF
--- a/src/base/simulation_results.jl
+++ b/src/base/simulation_results.jl
@@ -44,14 +44,14 @@ function _post_proc_state_series(solution, ix::Int, dt::Nothing)
 end
 
 function _post_proc_state_series(solution, ix::Int, dt::Float64)
-    ts = range(0; stop = solution.t[end], step = dt)
+    ts = collect(range(0; stop = solution.t[end], step = dt))
     state = solution(collect(ts); idxs = ix)
-    return ts, state
+    return ts, state.u
 end
 
 function _post_proc_state_series(solution, ix::Int, dt::Vector{Float64})
     state = solution(dt; idxs = ix)
-    return dt, state
+    return dt, state.u
 end
 
 """

--- a/src/base/simulation_results.jl
+++ b/src/base/simulation_results.jl
@@ -45,7 +45,7 @@ end
 
 function _post_proc_state_series(solution, ix::Int, dt::Float64)
     ts = collect(range(0; stop = solution.t[end], step = dt))
-    state = solution(collect(ts); idxs = ix)
+    state = solution(ts; idxs = ix)
     return ts, state.u
 end
 

--- a/test/test_base.jl
+++ b/test/test_base.jl
@@ -742,10 +742,14 @@ end
         series = get_state_series(results, ("generator-102-1", :δ); dt = 0.01)
         t = series[1]
         δ = series[2]
+        @test typeof(t) == Vector{Float64}
+        @test typeof(δ) == Vector{Float64}
         @test t[2] - t[1] == 0.01
         series = get_state_series(results, ("generator-102-1", :δ); dt = [0.02, 0.05])
         t = series[1]
         δ = series[2]
+        @test typeof(t) == Vector{Float64}
+        @test typeof(δ) == Vector{Float64}
         @test t[1] == 0.02
     finally
         @info("removing test files")


### PR DESCRIPTION
The post processing functions did not return Vector{Float64} when dt was passed. This makes the output the same regardless of dt being specified or not. 