### PR TITLE
Enable sensitivity analysis 

### DIFF
--- a/src/PowerSimulationsDynamics.jl
+++ b/src/PowerSimulationsDynamics.jl
@@ -184,5 +184,6 @@ include("utils/immutable_dicts.jl")
 include("utils/print.jl")
 include("utils/kwargs_check.jl")
 include("utils/logging.jl")
+include("utils/parameters.jl")
 
 end # module

--- a/src/base/branch_wrapper.jl
+++ b/src/base/branch_wrapper.jl
@@ -11,6 +11,7 @@ struct BranchWrapper
     bus_ix_to::Int
     ix_range::Vector{Int}
     ode_range::Vector{Int}
+    p_range::Vector{Int}
     global_index::Base.ImmutableDict{Symbol, Int}
     function BranchWrapper(
         branch::PSY.DynamicBranch,
@@ -18,6 +19,7 @@ struct BranchWrapper
         bus_ix_to::Int,
         ix_range,
         ode_range,
+        p_range,
         sys_base_power,
         sys_base_freq,
     )
@@ -31,6 +33,7 @@ struct BranchWrapper
             bus_ix_to,
             ix_range,
             ode_range,
+            p_range,
             Base.ImmutableDict(Dict(branch_states .=> ix_range)...),
         )
     end
@@ -41,6 +44,7 @@ get_bus_ix_from(wrapper::BranchWrapper) = wrapper.bus_ix_from
 get_bus_ix_to(wrapper::BranchWrapper) = wrapper.bus_ix_to
 get_ix_range(wrapper::BranchWrapper) = wrapper.ix_range
 get_ode_ouput_range(wrapper::BranchWrapper) = wrapper.ode_range
+get_p_range(wrapper::BranchWrapper) = wrapper.p_range
 get_global_index(wrapper::BranchWrapper) = wrapper.global_index
 get_branch(wrapper::BranchWrapper) = wrapper.branch
 

--- a/src/base/definitions.jl
+++ b/src/base/definitions.jl
@@ -101,6 +101,14 @@ end
 Base.to_index(ix::dq_ref) = Int(ix)
 Base.to_index(ix::RI_ref) = Int(ix)
 
+@enum ref_ix begin
+    Q_ref_ix = 1
+    V_ref_ix = 2
+    ω_ref_ix = 3
+    P_ref_ix = 4
+end
+Base.to_index(ix::ref_ix) = Int(ix)
+
 const MAPPING_DICT = Dict{String, OrderedDict{Symbol, Int}}
 const DEVICE_INTERNAL_MAPPING = Base.ImmutableDict{Int, Vector{Int}}
 

--- a/src/base/device_wrapper.jl
+++ b/src/base/device_wrapper.jl
@@ -22,67 +22,61 @@ index(::Type{<:PSY.Filter}) = 6
 
 """
 Wraps DynamicInjection devices from PowerSystems to handle changes in controls and connection
-status, and allocate the required indexes of the state space.
+status, and allocate the required indexes of the state space and parameter space. 
 """
 struct DynamicWrapper{T <: PSY.DynamicInjection}
-    device::T
+    dynamic_device::T
+    static_device::PSY.StaticInjection
     system_base_power::Float64
     system_base_frequency::Float64
-    static_type::Type{<:PSY.StaticInjection}
     bus_category::Type{<:BusCategory}
     connection_status::Base.RefValue{Float64}
-    V_ref::Base.RefValue{Float64}
-    ω_ref::Base.RefValue{Float64}
-    P_ref::Base.RefValue{Float64}
-    Q_ref::Base.RefValue{Float64}
     inner_vars_index::Vector{Int}
     ix_range::Vector{Int}
     ode_range::Vector{Int}
+    p_range::Vector{Int}
     bus_ix::Int
     global_index::Base.ImmutableDict{Symbol, Int}
     component_state_mapping::Base.ImmutableDict{Int, Vector{Int}}
+    component_parameter_mapping::Base.ImmutableDict{Int, Vector{Int}}
     input_port_mapping::Base.ImmutableDict{Int, Vector{Int}}
     ext::Dict{String, Any}
 
     function DynamicWrapper(
-        device::T,
+        dynamic_device::T,
+        static_device::V,
         system_base_power::Float64,
         system_base_frequency::Float64,
-        static_type::Type{<:PSY.StaticInjection},
         bus_category::Type{<:BusCategory},
         connection_status::Base.RefValue{Float64},
-        V_ref::Base.RefValue{Float64},
-        ω_ref::Base.RefValue{Float64},
-        P_ref::Base.RefValue{Float64},
-        Q_ref::Base.RefValue{Float64},
         inner_vars_index,
         ix_range,
         ode_range,
+        p_range,
         bus_ix::Int,
         global_index::Base.ImmutableDict{Symbol, Int},
         component_state_mapping::Base.ImmutableDict{Int, Vector{Int}},
+        component_parameter_mapping::Base.ImmutableDict{Int, Vector{Int}},
         input_port_mapping::Base.ImmutableDict{Int, Vector{Int}},
         ext::Dict{String, Any},
-    ) where {T <: PSY.DynamicInjection}
-        is_valid(device)
+    ) where {V <: PSY.StaticInjection, T <: PSY.DynamicInjection}
+        is_valid(dynamic_device)
 
         new{T}(
-            device,
+            dynamic_device,
+            static_device,
             system_base_power,
             system_base_frequency,
-            static_type,
             bus_category,
             connection_status,
-            V_ref,
-            ω_ref,
-            P_ref,
-            Q_ref,
             Vector{Int}(inner_vars_index),
             Vector{Int}(ix_range),
             Vector{Int}(ode_range),
+            Vector{Int}(p_range),
             bus_ix,
             global_index,
             component_state_mapping,
+            component_parameter_mapping,
             input_port_mapping,
             ext,
         )
@@ -109,42 +103,72 @@ function state_port_mappings(dynamic_device::PSY.DynamicInjection, device_states
     return (component_state_mapping, input_port_mapping)
 end
 
+function parameter_mappings(
+    dynamic_device::T,
+    device_parameters,
+) where {T <: Union{PSY.DynamicGenerator, PSY.DynamicInverter}}
+    component_parameter_mapping = Dict{Int, Vector{Int}}()
+    for c in PSY.get_dynamic_components(dynamic_device)
+        ix = index(typeof(c))
+        component_parameter_mapping[ix] = _index_local_parameters(c, device_parameters)
+    end
+    return component_parameter_mapping
+end
+
+function parameter_mappings(dynamic_device::PSY.DynamicInjection, device_parameters)
+    return Dict{Int, Vector{Int}}()
+end
+
+function _get_parameter_symbols(
+    dynamic_device::PSY.DynamicInjection,
+    static_device::PSY.StaticInjection,
+)
+    return get_params_symbol(dynamic_device)
+end
+
+function _get_parameter_symbols(
+    dynamic_device::T,
+    static_device::PSY.StaticInjection,
+) where {T <: Union{PSY.DynamicGenerator, PSY.DynamicInverter}}
+    return vcat(get_params_symbol(static_device), get_params_symbol(dynamic_device))
+end
+
 function DynamicWrapper(
-    device::T,
+    static_device::T,
     dynamic_device::D,
     bus_ix::Int,
     ix_range,
     ode_range,
+    p_range,
     inner_var_range,
     sys_base_power,
     sys_base_freq,
 ) where {T <: PSY.StaticInjection, D <: PSY.DynamicInjection}
     device_states = PSY.get_states(dynamic_device)
+    device_parameters = _get_parameter_symbols(dynamic_device, static_device)
+    @assert allunique(device_parameters)    #mapping depends on unique parameters per device
 
     component_state_mapping, input_port_mapping =
         state_port_mappings(dynamic_device, device_states)
-
+    component_parameter_mapping = parameter_mappings(dynamic_device, device_parameters)
     # Consider the special case when the static device is StandardLoad
-    if isa(device, PSY.StandardLoad)
-        reactive_power = PF.get_total_q(device)
+    if isa(static_device, PSY.StandardLoad)
+        reactive_power = PF.get_total_q(static_device)
     else
-        reactive_power = PSY.get_reactive_power(device)
+        reactive_power = PSY.get_reactive_power(static_device)
     end
 
     return DynamicWrapper(
         dynamic_device,
+        static_device,
         sys_base_power,
         sys_base_freq,
-        T,
-        BUS_MAP[PSY.get_bustype(PSY.get_bus(device))],
+        BUS_MAP[PSY.get_bustype(PSY.get_bus(static_device))],
         Base.Ref(1.0),
-        Base.Ref(PSY.get_V_ref(dynamic_device)),
-        Base.Ref(PSY.get_ω_ref(dynamic_device)),
-        Base.Ref(PSY.get_P_ref(dynamic_device)),
-        Base.Ref(reactive_power),
         inner_var_range,
         ix_range,
         ode_range,
+        p_range,
         bus_ix,
         Base.ImmutableDict(
             sort!(device_states .=> ix_range; by = x -> x.second, rev = true)...,
@@ -153,6 +177,11 @@ function DynamicWrapper(
             Base.ImmutableDict{Int, Vector{Int}}()
         else
             Base.ImmutableDict(component_state_mapping...)
+        end,
+        if isempty(component_parameter_mapping)
+            Base.ImmutableDict{Int, Vector{Int}}()
+        else
+            Base.ImmutableDict(component_parameter_mapping...)
         end,
         if isempty(input_port_mapping)
             Base.ImmutableDict{Int, Vector{Int}}()
@@ -164,11 +193,12 @@ function DynamicWrapper(
 end
 
 function DynamicWrapper(
-    device::PSY.ThermalStandard,
+    static_device::PSY.ThermalStandard,
     dynamic_device::PSY.AggregateDistributedGenerationA,
     bus_ix::Int,
     ix_range,
     ode_range,
+    p_range,
     inner_var_range,
     sys_base_power,
     sys_base_freq,
@@ -181,18 +211,15 @@ function DynamicWrapper(
 
     return DynamicWrapper(
         dynamic_device,
+        static_device,
         sys_base_power,
         sys_base_freq,
-        PSY.ThermalStandard,
-        BUS_MAP[PSY.get_bustype(PSY.get_bus(device))],
+        BUS_MAP[PSY.get_bustype(PSY.get_bus(static_device))],
         Base.Ref(1.0),
-        Base.Ref(PSY.get_V_ref(dynamic_device)),
-        Base.Ref(PSY.get_ω_ref(dynamic_device)),
-        Base.Ref(PSY.get_P_ref(dynamic_device)),
-        Base.Ref(PSY.get_reactive_power(device)),
         inner_var_range,
         ix_range,
         ode_range,
+        p_range,
         bus_ix,
         Base.ImmutableDict(
             sort!(device_states .=> ix_range; by = x -> x.second, rev = true)...,
@@ -202,6 +229,7 @@ function DynamicWrapper(
         else
             Base.ImmutableDict(component_state_mapping...)
         end,
+        Base.ImmutableDict{Int, Vector{Int}}(),
         if isempty(input_port_mapping)
             Base.ImmutableDict{Int, Vector{Int}}()
         else
@@ -212,39 +240,50 @@ function DynamicWrapper(
 end
 
 function DynamicWrapper(
-    device::PSY.Source,
+    static_device::PSY.Source,
     dynamic_device::D,
     bus_ix::Int,
     ix_range,
     ode_range,
+    p_range,
     inner_var_range,
     sys_base_power,
     sys_base_freq,
 ) where {D <: PSY.DynamicInjection}
     device_states = PSY.get_states(dynamic_device)
-    IS.@assert_op PSY.get_X_th(dynamic_device) == PSY.get_X_th(device)
-    IS.@assert_op PSY.get_R_th(dynamic_device) == PSY.get_R_th(device)
+    IS.@assert_op PSY.get_X_th(dynamic_device) == PSY.get_X_th(static_device)
+    IS.@assert_op PSY.get_R_th(dynamic_device) == PSY.get_R_th(static_device)
 
     return DynamicWrapper(
         dynamic_device,
+        static_device,
         sys_base_power,
         sys_base_freq,
-        PSY.Source,
-        BUS_MAP[PSY.get_bustype(PSY.get_bus(device))],
+        BUS_MAP[PSY.get_bustype(PSY.get_bus(static_device))],
         Base.Ref(1.0),
-        Base.Ref(0.0),
-        Base.Ref(0.0),
-        Base.Ref(0.0),
-        Base.Ref(0.0),
         collect(inner_var_range),
         collect(ix_range),
         collect(ode_range),
+        collect(p_range),
         bus_ix,
         Base.ImmutableDict(Dict(device_states .=> ix_range)...),
         Base.ImmutableDict{Int, Vector{Int}}(),
         Base.ImmutableDict{Int, Vector{Int}}(),
+        Base.ImmutableDict{Int, Vector{Int}}(),
         Dict{String, Any}(),
     )
+end
+
+function _index_local_parameters(
+    component::PSY.DynamicComponent,
+    device_parameters::Vector{Symbol},
+)
+    component_paramter_index = Vector{Int}(undef, get_n_params(component))
+    component_parameters = get_params_symbol(component)
+    for (ix, s) in enumerate(component_parameters)
+        component_paramter_index[ix] = findfirst(x -> x == s, device_parameters)
+    end
+    return component_paramter_index
 end
 
 function _index_local_states(component::PSY.DynamicComponent, device_states::Vector{Symbol})
@@ -270,61 +309,55 @@ function _index_port_mapping!(
     return index_component_inputs
 end
 
-get_device(wrapper::DynamicWrapper) = wrapper.device
+get_dynamic_device(wrapper::DynamicWrapper) = wrapper.dynamic_device
+get_static_device(wrapper::DynamicWrapper) = wrapper.static_device
 get_device_type(::DynamicWrapper{T}) where {T <: PSY.DynamicInjection} = T
 get_bus_category(wrapper::DynamicWrapper) = wrapper.bus_category
 get_inner_vars_index(wrapper::DynamicWrapper) = wrapper.inner_vars_index
 get_ix_range(wrapper::DynamicWrapper) = wrapper.ix_range
 get_ode_ouput_range(wrapper::DynamicWrapper) = wrapper.ode_range
+get_p_range(wrapper::DynamicWrapper) = wrapper.p_range
 get_bus_ix(wrapper::DynamicWrapper) = wrapper.bus_ix
 get_global_index(wrapper::DynamicWrapper) = wrapper.global_index
 get_component_state_mapping(wrapper::DynamicWrapper) = wrapper.component_state_mapping
+get_component_parameter_mapping(wrapper::DynamicWrapper) =
+    wrapper.component_parameter_mapping
 get_input_port_mapping(wrapper::DynamicWrapper) = wrapper.input_port_mapping
 get_ext(wrapper::DynamicWrapper) = wrapper.ext
 
 get_system_base_power(wrapper::DynamicWrapper) = wrapper.system_base_power
 get_system_base_frequency(wrapper::DynamicWrapper) = wrapper.system_base_frequency
 
-get_P_ref(wrapper::DynamicWrapper) = wrapper.P_ref[]
-get_Q_ref(wrapper::DynamicWrapper) = wrapper.Q_ref[]
-get_V_ref(wrapper::DynamicWrapper) = wrapper.V_ref[]
-get_ω_ref(wrapper::DynamicWrapper) = wrapper.ω_ref[]
-
-set_P_ref(wrapper::DynamicWrapper, val::Float64) = wrapper.P_ref[] = val
-set_Q_ref(wrapper::DynamicWrapper, val::Float64) = wrapper.Q_ref[] = val
-set_V_ref(wrapper::DynamicWrapper, val::Float64) = wrapper.V_ref[] = val
-set_ω_ref(wrapper::DynamicWrapper, val::Float64) = wrapper.ω_ref[] = val
-
 # PSY overloads for the wrapper
-PSY.get_name(wrapper::DynamicWrapper) = PSY.get_name(wrapper.device)
-PSY.get_ext(wrapper::DynamicWrapper) = PSY.get_ext(wrapper.device)
-PSY.get_states(wrapper::DynamicWrapper) = PSY.get_states(wrapper.device)
-PSY.get_n_states(wrapper::DynamicWrapper) = PSY.get_n_states(wrapper.device)
-PSY.get_base_power(wrapper::DynamicWrapper) = PSY.get_base_power(wrapper.device)
+PSY.get_name(wrapper::DynamicWrapper) = PSY.get_name(wrapper.dynamic_device)
+PSY.get_ext(wrapper::DynamicWrapper) = PSY.get_ext(wrapper.dynamic_device)
+PSY.get_states(wrapper::DynamicWrapper) = PSY.get_states(wrapper.dynamic_device)
+PSY.get_n_states(wrapper::DynamicWrapper) = PSY.get_n_states(wrapper.dynamic_device)
+PSY.get_base_power(wrapper::DynamicWrapper) = PSY.get_base_power(wrapper.dynamic_device)
 
 PSY.get_machine(wrapper::DynamicWrapper{T}) where {T <: PSY.DynamicGenerator} =
-    wrapper.device.machine
+    wrapper.dynamic_device.machine
 PSY.get_shaft(wrapper::DynamicWrapper{T}) where {T <: PSY.DynamicGenerator} =
-    wrapper.device.shaft
+    wrapper.dynamic_device.shaft
 PSY.get_avr(wrapper::DynamicWrapper{T}) where {T <: PSY.DynamicGenerator} =
-    wrapper.device.avr
+    wrapper.dynamic_device.avr
 PSY.get_prime_mover(wrapper::DynamicWrapper{T}) where {T <: PSY.DynamicGenerator} =
-    wrapper.device.prime_mover
+    wrapper.dynamic_device.prime_mover
 PSY.get_pss(wrapper::DynamicWrapper{T}) where {T <: PSY.DynamicGenerator} =
-    wrapper.device.pss
+    wrapper.dynamic_device.pss
 
 PSY.get_converter(wrapper::DynamicWrapper{T}) where {T <: PSY.DynamicInverter} =
-    wrapper.device.converter
+    wrapper.dynamic_device.converter
 PSY.get_outer_control(wrapper::DynamicWrapper{T}) where {T <: PSY.DynamicInverter} =
-    wrapper.device.outer_control
+    wrapper.dynamic_device.outer_control
 PSY.get_inner_control(wrapper::DynamicWrapper{T}) where {T <: PSY.DynamicInverter} =
-    wrapper.device.inner_control
+    wrapper.dynamic_device.inner_control
 PSY.get_dc_source(wrapper::DynamicWrapper{T}) where {T <: PSY.DynamicInverter} =
-    wrapper.device.dc_source
+    wrapper.dynamic_device.dc_source
 PSY.get_freq_estimator(wrapper::DynamicWrapper{T}) where {T <: PSY.DynamicInverter} =
-    wrapper.device.freq_estimator
+    wrapper.dynamic_device.freq_estimator
 PSY.get_filter(wrapper::DynamicWrapper{T}) where {T <: PSY.DynamicInverter} =
-    wrapper.device.filter
+    wrapper.dynamic_device.filter
 
 # PSY overloads of specific Dynamic Injectors
 
@@ -340,6 +373,13 @@ function get_local_state_ix(
     ::Type{T},
 ) where {T <: PSY.DynamicComponent}
     return wrapper.component_state_mapping[index(T)]
+end
+
+function get_local_parameter_ix(
+    wrapper::DynamicWrapper,
+    ::Type{T},
+) where {T <: PSY.DynamicComponent}
+    return wrapper.component_parameter_mapping[index(T)]
 end
 
 function get_input_port_ix(
@@ -360,10 +400,7 @@ end
 struct StaticWrapper{T <: PSY.StaticInjection, V}
     device::T
     connection_status::Base.RefValue{Float64}
-    V_ref::Base.RefValue{Float64}
-    θ_ref::Base.RefValue{Float64}
-    P_ref::Base.RefValue{Float64}
-    Q_ref::Base.RefValue{Float64}
+    p_range::Vector{Int}
     bus_ix::Int
     ext::Dict{String, Any}
 end
@@ -373,24 +410,18 @@ function DynamicWrapper(device::T, bus_ix::Int) where {T <: PSY.Device}
     StaticWrapper{T, BUS_MAP[PSY.get_bustype(bus)]}(
         device,
         Base.Ref(1.0),
-        Base.Ref(PSY.get_magnitude(bus)),
-        Base.Ref(PSY.get_angle(bus)),
-        Base.Ref(PSY.get_active_power(device)),
-        Base.Ref(PSY.get_reactive_power(device)),
+        Vector{Int}(),
         bus_ix,
         Dict{String, Any}(),
     )
 end
 
-function StaticWrapper(device::T, bus_ix::Int) where {T <: PSY.Source}
+function StaticWrapper(device::T, bus_ix::Int, p_range) where {T <: PSY.Source}
     bus = PSY.get_bus(device)
     return StaticWrapper{T, BUS_MAP[PSY.get_bustype(bus)]}(
         device,
         Base.Ref(1.0),
-        Base.Ref(PSY.get_internal_voltage(device)),
-        Base.Ref(PSY.get_internal_angle(device)),
-        Base.Ref(PSY.get_active_power(device)),
-        Base.Ref(PSY.get_reactive_power(device)),
+        p_range,
         bus_ix,
         Dict{String, Any}(),
     )
@@ -401,18 +432,9 @@ get_bus_category(::StaticWrapper{<:PSY.StaticInjection, U}) where {U} = U
 
 # TODO: something smart to forward fields
 get_device(wrapper::StaticWrapper) = wrapper.device
+get_p_range(wrapper::StaticWrapper) = wrapper.p_range
 get_bus_ix(wrapper::StaticWrapper) = wrapper.bus_ix
 get_ext(wrapper::StaticWrapper) = wrapper.ext
-
-get_P_ref(wrapper::StaticWrapper) = wrapper.P_ref[]
-get_Q_ref(wrapper::StaticWrapper) = wrapper.Q_ref[]
-get_V_ref(wrapper::StaticWrapper) = wrapper.V_ref[]
-get_θ_ref(wrapper::StaticWrapper) = wrapper.θ_ref[]
-
-set_P_ref(wrapper::StaticWrapper, val::Float64) = wrapper.P_ref[] = val
-set_Q_ref(wrapper::StaticWrapper, val::Float64) = wrapper.Q_ref[] = val
-set_V_ref(wrapper::StaticWrapper, val::Float64) = wrapper.V_ref[] = val
-set_θ_ref(wrapper::StaticWrapper, val::Float64) = wrapper.θ_ref[] = val
 
 PSY.get_bus(wrapper::StaticWrapper) = PSY.get_bus(wrapper.device)
 PSY.get_active_power(wrapper::StaticWrapper) = PSY.get_active_power(wrapper.device)
@@ -428,48 +450,22 @@ mutable struct ExpLoadParams
 end
 
 mutable struct StaticLoadWrapper
+    loads::Vector{PSY.ElectricLoad}
     bus::PSY.Bus
-    V_ref::Float64
-    θ_ref::Float64
-    P_power::Float64
-    P_current::Float64
-    P_impedance::Float64
-    Q_power::Float64
-    Q_current::Float64
-    Q_impedance::Float64
     exp_params::Vector{ExpLoadParams}
     exp_names::Dict{String, Int}
+    p_range::Vector{Int}
     bus_ix::Int
+    system_base_power::Float64
 end
 
 function StaticLoadWrapper(
     bus::PSY.Bus,
     loads::Vector{PSY.ElectricLoad},
+    p_range,
     bus_ix::Int,
     sys_base_power::Float64,
 )
-    P_power = 0.0
-    P_current = 0.0
-    P_impedance = 0.0
-    Q_power = 0.0
-    Q_current = 0.0
-    Q_impedance = 0.0
-
-    # Add ZIP Loads
-    for ld in loads
-        base_power_conversion = PSY.get_base_power(ld) / sys_base_power
-        if isa(ld, PSY.PowerLoad)
-            P_power += PSY.get_active_power(ld) * base_power_conversion
-            Q_power += PSY.get_reactive_power(ld) * base_power_conversion
-        elseif isa(ld, PSY.StandardLoad)
-            P_impedance += PSY.get_impedance_active_power(ld) * base_power_conversion
-            Q_impedance += PSY.get_impedance_reactive_power(ld) * base_power_conversion
-            P_current += PSY.get_current_active_power(ld) * base_power_conversion
-            Q_current += PSY.get_current_reactive_power(ld) * base_power_conversion
-            P_power += PSY.get_constant_active_power(ld) * base_power_conversion
-            Q_power += PSY.get_constant_reactive_power(ld) * base_power_conversion
-        end
-    end
 
     # Add Exponential Loads
     exp_loads = filter(x -> isa(x, PSY.ExponentialLoad) && PSY.get_available(x), loads)
@@ -489,35 +485,25 @@ function StaticLoadWrapper(
     end
 
     return StaticLoadWrapper(
+        loads,
         bus,
-        PSY.get_magnitude(bus),
-        PSY.get_angle(bus),
-        P_power,
-        P_current,
-        P_impedance,
-        Q_power,
-        Q_current,
-        Q_impedance,
         exp_params,
         dict_names,
+        p_range,
         bus_ix,
+        sys_base_power,
     )
 end
 
 PSY.get_bus(wrapper::StaticLoadWrapper) = wrapper.bus
 PSY.get_name(wrapper::StaticLoadWrapper) = PSY.get_name(wrapper.bus)
 
-get_V_ref(wrapper::StaticLoadWrapper) = wrapper.V_ref
-get_θ_ref(wrapper::StaticLoadWrapper) = wrapper.θ_ref
-get_P_power(wrapper::StaticLoadWrapper) = wrapper.P_power
-get_P_current(wrapper::StaticLoadWrapper) = wrapper.P_current
-get_P_impedance(wrapper::StaticLoadWrapper) = wrapper.P_impedance
-get_Q_power(wrapper::StaticLoadWrapper) = wrapper.Q_power
-get_Q_current(wrapper::StaticLoadWrapper) = wrapper.Q_current
-get_Q_impedance(wrapper::StaticLoadWrapper) = wrapper.Q_impedance
+get_loads(wrapper::StaticLoadWrapper) = wrapper.loads
+get_p_range(wrapper::StaticLoadWrapper) = wrapper.p_range
 get_exp_params(wrapper::StaticLoadWrapper) = wrapper.exp_params
 get_exp_names(wrapper::StaticLoadWrapper) = wrapper.exp_names
 get_bus_ix(wrapper::StaticLoadWrapper) = wrapper.bus_ix
+get_system_base_power(wrapper::StaticLoadWrapper) = wrapper.system_base_power
 
 set_V_ref!(wrapper::StaticLoadWrapper, val::Float64) = wrapper.V_ref = val
 set_θ_ref!(wrapper::StaticLoadWrapper, val::Float64) = wrapper.θ_ref = val

--- a/src/base/simulation_results.jl
+++ b/src/base/simulation_results.jl
@@ -44,14 +44,14 @@ function _post_proc_state_series(solution, ix::Int, dt::Nothing)
 end
 
 function _post_proc_state_series(solution, ix::Int, dt::Float64)
-    ts = range(0; stop = solution.t[end], step = dt)
-    state = solution(collect(ts); idxs = ix)
-    return ts, state
+    ts = collect(range(0; stop = solution.t[end], step = dt))
+    state = solution(ts; idxs = ix)
+    return ts, state.u
 end
 
 function _post_proc_state_series(solution, ix::Int, dt::Vector{Float64})
     state = solution(dt; idxs = ix)
-    return dt, state
+    return dt, state.u
 end
 
 """

--- a/src/initialization/generator_components/init_pss.jl
+++ b/src/initialization/generator_components/init_pss.jl
@@ -1,5 +1,6 @@
 function initialize_pss!(
     device_states,
+    device_parameters,
     static::PSY.StaticInjection,
     dynamic_device::DynamicWrapper{PSY.DynamicGenerator{M, S, A, TG, PSY.PSSFixed}},
     inner_vars::AbstractVector,
@@ -7,6 +8,7 @@ function initialize_pss!(
 
 function initialize_pss!(
     device_states,
+    device_parameters,
     static::PSY.StaticInjection,
     dynamic_device::DynamicWrapper{PSY.DynamicGenerator{M, S, A, TG, PSY.IEEEST}},
     inner_vars::AbstractVector,
@@ -116,15 +118,14 @@ end
 
 function initialize_pss!(
     device_states,
+    device_parameters,
     static::PSY.StaticInjection,
     dynamic_device::DynamicWrapper{PSY.DynamicGenerator{M, S, A, TG, PSY.STAB1}},
     inner_vars::AbstractVector,
 ) where {M <: PSY.Machine, S <: PSY.Shaft, A <: PSY.AVR, TG <: PSY.TurbineGov}
-    #Get Signal Input Integer
-    pss = PSY.get_pss(dynamic_device)
 
     #Obtain PSS States
-    pss_ix = get_local_state_ix(dynamic_device, typeof(pss))
+    pss_ix = get_local_state_ix(dynamic_device, PSY.STAB1)
     pss_states = @view device_states[pss_ix]
 
     #Compute steady-state values
@@ -147,6 +148,7 @@ end
 
 function initialize_pss!(
     device_states,
+    device_parameters,
     static::PSY.StaticInjection,
     dynamic_device::DynamicWrapper{PSY.DynamicGenerator{M, S, A, TG, PSY.PSS2A}},
     inner_vars::AbstractVector,
@@ -270,6 +272,7 @@ end
 
 function initialize_pss!(
     device_states,
+    device_parameters,
     static::PSY.StaticInjection,
     dynamic_device::DynamicWrapper{PSY.DynamicGenerator{M, S, A, TG, PSY.PSS2B}},
     inner_vars::AbstractVector,
@@ -406,6 +409,7 @@ end
 
 function initialize_pss!(
     device_states,
+    device_parameters,
     static::PSY.StaticInjection,
     dynamic_device::DynamicWrapper{PSY.DynamicGenerator{M, S, A, TG, PSY.PSS2C}},
     inner_vars::AbstractVector,

--- a/src/initialization/generator_components/init_shaft.jl
+++ b/src/initialization/generator_components/init_shaft.jl
@@ -1,5 +1,6 @@
 function initialize_shaft!(
     device_states,
+    device_parameters,
     static::PSY.StaticInjection,
     dynamic_device::DynamicWrapper{PSY.DynamicGenerator{M, PSY.SingleMass, A, TG, P}},
     inner_vars::AbstractVector,
@@ -7,6 +8,7 @@ function initialize_shaft!(
 
 function initialize_shaft!(
     device_states,
+    device_parameters,
     static::PSY.StaticInjection,
     dynamic_device::DynamicWrapper{PSY.DynamicGenerator{M, PSY.FiveMassShaft, A, TG, P}},
     inner_vars::AbstractVector,
@@ -22,21 +24,27 @@ function initialize_shaft!(
     ω_ex = ω
     ω_sys = ω
 
-    #Obtain parameters
-    shaft = PSY.get_shaft(dynamic_device)
-    D = PSY.get_D(shaft)
-    D_hp = PSY.get_D_hp(shaft)
-    D_ip = PSY.get_D_ip(shaft)
-    D_lp = PSY.get_D_lp(shaft)
-    D_ex = PSY.get_D_ex(shaft)
-    D_12 = PSY.get_D_12(shaft)
-    D_23 = PSY.get_D_23(shaft)
-    D_34 = PSY.get_D_34(shaft)
-    D_45 = PSY.get_D_45(shaft)
-    K_hp = PSY.get_K_hp(shaft)
-    K_ip = PSY.get_K_ip(shaft)
-    K_lp = PSY.get_K_lp(shaft)
-    K_ex = PSY.get_K_ex(shaft)
+    #Get parameters
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.SingleMass)
+    internal_params = @view device_parameters[local_ix_params]
+    _,
+    _,
+    _,
+    _,
+    _,
+    D,
+    D_hp,
+    D_ip,
+    D_lp,
+    D_ex,
+    D_12,
+    D_23,
+    D_34,
+    D_45,
+    K_hp,
+    K_ip,
+    K_lp,
+    K_ex = internal_params
 
     #Obtain inner vars
     τe = inner_vars[τe_var]

--- a/src/initialization/inverter_components/init_DCside.jl
+++ b/src/initialization/inverter_components/init_DCside.jl
@@ -1,5 +1,6 @@
 function initialize_DCside!(
     device_states,
+    device_parameters,
     static::PSY.StaticInjection,
     dynamic_device::DynamicWrapper{
         PSY.DynamicInverter{C, O, IC, PSY.FixedDCSource, P, F, L},
@@ -13,8 +14,9 @@ function initialize_DCside!(
     F <: PSY.Filter,
     L <: Union{Nothing, PSY.InverterLimiter},
 }
-
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.FixedDCSource)
+    internal_params = @view device_parameters[local_ix_params]
     #Update inner_vars
-    inner_vars[Vdc_var] = PSY.get_voltage(PSY.get_dc_source(dynamic_device))
+    inner_vars[Vdc_var] = internal_params[1]
     return
 end

--- a/src/initialization/inverter_components/init_converter.jl
+++ b/src/initialization/inverter_components/init_converter.jl
@@ -1,5 +1,6 @@
 function initialize_converter!(
     device_states,
+    device_parameters,
     static::PSY.StaticInjection,
     dynamic_device::DynamicWrapper{
         PSY.DynamicInverter{PSY.AverageConverter, O, IC, DC, P, F, L},
@@ -16,6 +17,7 @@ function initialize_converter!(
 
 function initialize_converter!(
     device_states,
+    device_parameters,
     static::PSY.StaticInjection,
     dynamic_device::DynamicWrapper{
         PSY.DynamicInverter{PSY.RenewableEnergyConverterTypeA, O, IC, DC, P, F, L},
@@ -42,9 +44,29 @@ function initialize_converter!(
     #Reference Transformation
     Ip = Ip_external * cos(-θ) - Iq_external * sin(-θ)
     Iq = Ip_external * sin(-θ) + Iq_external * cos(-θ)
+
+    #Get Converter parameters
     converter = PSY.get_converter(dynamic_device)
-    Io_lim = PSY.get_Io_lim(converter)
-    Vo_lim = PSY.get_Vo_lim(converter)
+    local_ix_params =
+        get_local_parameter_ix(dynamic_device, PSY.RenewableEnergyConverterTypeA)
+    internal_params = @view device_parameters[local_ix_params]
+    T_g,
+    Rrpwr,
+    Brkpt,
+    Zerox,
+    Lvpl1,
+    Vo_lim,
+    Lv_pnt0,
+    Lv_pnt1,
+    Io_lim,
+    T_fltr,
+    K_hv,
+    Iqr_min,
+    Iqr_max,
+    Accel,
+    Q_ref,
+    R_source,
+    X_source = internal_params
 
     # Lv_pnt0 is unused in the initialization
     _, Lv_pnt1 = PSY.get_Lv_pnts(converter)
@@ -71,6 +93,7 @@ end
 
 function initialize_converter!(
     device_states,
+    device_parameters,
     static::PSY.StaticInjection,
     dynamic_device::DynamicWrapper{
         PSY.DynamicInverter{PSY.RenewableEnergyVoltageConverterTypeA, O, IC, DC, P, F, L},

--- a/src/initialization/inverter_components/init_outer.jl
+++ b/src/initialization/inverter_components/init_outer.jl
@@ -1,5 +1,6 @@
 function initialize_outer!(
     device_states,
+    device_parameters,
     static::PSY.StaticInjection,
     dynamic_device::DynamicWrapper{
         PSY.DynamicInverter{
@@ -36,6 +37,7 @@ function initialize_outer!(
     Vi_cnv = inner_vars[Vi_cnv_var]
     θ0_oc = atan(Vi_cnv, Vr_cnv)
 
+    ω_ref = device_parameters[ω_ref_ix]
     #Obtain additional expressions
     p_elec_out = Ir_filter * Vr_filter + Ii_filter * Vi_filter
     q_elec_out = -Ii_filter * Vr_filter + Ir_filter * Vi_filter
@@ -49,24 +51,25 @@ function initialize_outer!(
     )
     outer_states = @view device_states[outer_ix]
     outer_states[1] = θ0_oc #θ_oc
-    outer_states[2] = get_ω_ref(dynamic_device) #ω
+    outer_states[2] = ω_ref
     outer_states[3] = q_elec_out #qm
 
     #Update inner vars
     inner_vars[θ_oc_var] = θ0_oc
-    inner_vars[ω_oc_var] = get_ω_ref(dynamic_device)
-    #Update Q_ref. Initialization assumes q_ref = q_elec_out of PF solution
-    set_P_ref(dynamic_device, p_elec_out)
+    inner_vars[ω_oc_var] = ω_ref
+    device_parameters[P_ref_ix] = p_elec_out
     PSY.set_P_ref!(
         PSY.get_active_power_control(PSY.get_outer_control(dynamic_device)),
         p_elec_out,
     )
-    set_Q_ref(dynamic_device, q_elec_out)
+    #Update Q_ref. Initialization assumes q_ref = q_elec_out of PF solution
+    device_parameters[Q_ref_ix] = q_elec_out
     return
 end
 
 function initialize_outer!(
     device_states,
+    device_parameters,
     static::PSY.StaticInjection,
     dynamic_device::DynamicWrapper{
         PSY.DynamicInverter{
@@ -121,18 +124,19 @@ function initialize_outer!(
 
     #Update inner vars
     inner_vars[θ_oc_var] = θ0_oc
-    inner_vars[ω_oc_var] = get_ω_ref(dynamic_device)
+    inner_vars[ω_oc_var] = device_parameters[ω_ref_ix]
     #Update Q_ref. Initialization assumes q_ref = q_elec_out of PF solution
-    set_P_ref(dynamic_device, p_elec_out)
+    device_parameters[P_ref_ix] = p_elec_out
     PSY.set_P_ref!(
         PSY.get_active_power_control(PSY.get_outer_control(dynamic_device)),
         p_elec_out,
     )
-    set_Q_ref(dynamic_device, q_elec_out)
+    device_parameters[Q_ref_ix] = q_elec_out
 end
 
 function initialize_outer!(
     device_states,
+    device_parameters,
     static::PSY.StaticInjection,
     dynamic_device::DynamicWrapper{
         PSY.DynamicInverter{
@@ -186,18 +190,19 @@ function initialize_outer!(
 
     #Update inner vars
     inner_vars[θ_oc_var] = θ0_oc
-    inner_vars[ω_oc_var] = get_ω_ref(dynamic_device)
+    inner_vars[ω_oc_var] = device_parameters[ω_ref_ix]
     #Update Q_ref. Initialization assumes q_ref = q_elec_out of PF solution
-    set_P_ref(dynamic_device, p_elec_out)
+    device_parameters[P_ref_ix] = p_elec_out
     PSY.set_P_ref!(
         PSY.get_active_power_control(PSY.get_outer_control(dynamic_device)),
         p_elec_out,
     )
-    set_Q_ref(dynamic_device, q_elec_out)
+    device_parameters[Q_ref_ix] = q_elec_out
 end
 
 function initialize_outer!(
     device_states,
+    device_parameters,
     static::PSY.StaticInjection,
     dynamic_device::DynamicWrapper{
         PSY.DynamicInverter{
@@ -260,16 +265,16 @@ function initialize_outer!(
 
     #Update inner vars
     inner_vars[θ_oc_var] = θ0_oc
-    inner_vars[ω_oc_var] = get_ω_ref(dynamic_device)
+    inner_vars[ω_oc_var] = device_parameters[ω_ref_ix]
     inner_vars[Id_oc_var] = I_dq_cnv[d]
     inner_vars[Iq_oc_var] = I_dq_cnv[q]
     #Update Q_ref. Initialization assumes q_ref = q_elec_out from PF solution
-    set_P_ref(dynamic_device, p_elec_out)
+    device_parameters[P_ref_ix] = p_elec_out
     PSY.set_P_ref!(
         PSY.get_active_power_control(PSY.get_outer_control(dynamic_device)),
         p_elec_out,
     )
-    set_Q_ref(dynamic_device, q_elec_out)
+    device_parameters[Q_ref_ix] = q_elec_out
     PSY.set_Q_ref!(
         PSY.get_reactive_power_control(PSY.get_outer_control(dynamic_device)),
         q_elec_out,
@@ -279,6 +284,7 @@ end
 
 function initialize_outer!(
     device_states,
+    device_parameters,
     static::PSY.StaticInjection,
     dynamic_device::DynamicWrapper{
         PSY.DynamicInverter{
@@ -322,7 +328,7 @@ function initialize_outer!(
     ## Set references
     Vm = V_t
     PSY.set_Q_ref!(PSY.get_converter(dynamic_device), q_elec_out)
-    set_Q_ref(dynamic_device, q_elec_out)
+    device_parameters[Q_ref_ix] = q_elec_out
     PSY.set_Q_ref!(
         PSY.get_reactive_power_control(PSY.get_outer_control(dynamic_device)),
         q_elec_out,
@@ -331,17 +337,18 @@ function initialize_outer!(
         PSY.get_active_power_control(PSY.get_outer_control(dynamic_device)),
         p_elec_out,
     )
-    set_P_ref(dynamic_device, p_elec_out)
+    device_parameters[P_ref_ix] = p_elec_out
     PSY.set_V_ref!(
         PSY.get_reactive_power_control(PSY.get_outer_control(dynamic_device)),
         Vm,
     )
-    set_V_ref(dynamic_device, Vm)
+    device_parameters[V_ref_ix] = Vm
 
     #Get Outer Controller parameters
-    q_ref = get_Q_ref(dynamic_device)
+    q_ref = device_parameters[Q_ref_ix]
     outer_control = PSY.get_outer_control(dynamic_device)
     active_power_control = PSY.get_active_power_control(outer_control)
+    reactive_power_control = PSY.get_reactive_power_control(outer_control)
     Freq_Flag = PSY.get_Freq_Flag(active_power_control) #Frequency Flag
 
     #Set state counter for variable number of states due to flags
@@ -360,9 +367,62 @@ function initialize_outer!(
     )
     internal_states = @view device_states[local_ix]
 
+    #Get all parameters once 
+    local_ix_params = get_local_parameter_ix(
+        dynamic_device,
+        PSY.OuterControl{
+            PSY.ActiveRenewableControllerAB,
+            PSY.ReactiveRenewableControllerAB,
+        },
+    )
+    internal_params = @view device_parameters[local_ix_params]
+    active_n_params = get_n_params(active_power_control)
+    active_ix_range_params = 1:active_n_params
+    active_params = @view internal_params[active_ix_range_params]
+    reactive_n_params = get_n_params(reactive_power_control)
+    reactive_ix_range_params = (active_n_params + 1):(active_n_params + reactive_n_params)
+    reactive_params = @view internal_params[reactive_ix_range_params]
+    K_pg,
+    K_ig,
+    T_p,
+    fdbd1,
+    fdbd2,
+    fe_min,
+    fe_max,
+    P_min,
+    P_max,
+    T_g,
+    D_dn,
+    D_up,
+    dP_min,
+    dP_max,
+    P_min_inner,
+    P_max_inner,
+    T_pord = active_params
+    T_fltr,
+    K_p,
+    K_i,
+    T_ft,
+    T_fv,
+    V_frz,     # V_frz not implemented yet
+    R_c,
+    X_c,
+    K_c,
+    e_min,
+    e_max,
+    dbd1,
+    dbd2,
+    Q_min,
+    Q_max,
+    T_p,
+    Q_min_inner,
+    Q_max_inner,
+    V_min,
+    V_max,
+    K_qp,
+    K_qi = reactive_params
+
     if Freq_Flag == 1
-        #Obtain Parameters
-        K_ig = PSY.get_K_ig(active_power_control)
         #Update States
         internal_states[state_ct] = p_elec_out
         internal_states[state_ct + 1] = p_elec_out / K_ig
@@ -387,9 +447,6 @@ function initialize_outer!(
     V_Flag = PSY.get_V_Flag(reactive_power_control)
     # Update references
     if Ref_Flag == 0 && PF_Flag == 0 && V_Flag == 1
-        #Get Reactive Controller Parameters
-        K_i = PSY.get_K_i(reactive_power_control)
-        K_qi = PSY.get_K_qi(reactive_power_control)
         #Update states
         internal_states[state_ct] = q_elec_out
         internal_states[state_ct + 1] = q_elec_out / K_i
@@ -400,7 +457,6 @@ function initialize_outer!(
         inner_vars[V_oc_var] = 0.0
         inner_vars[Iq_oc_var] = q_elec_out / max(V_t, 0.01)
     elseif Ref_Flag == 0 && PF_Flag == 0 && V_Flag == 0
-        K_i = PSY.get_K_i(reactive_power_control)
         #Update states
         internal_states[state_ct] = q_ref
         internal_states[state_ct + 1] = q_ref / K_i
@@ -438,11 +494,6 @@ function initialize_outer!(
         inner_vars[Iq_oc_var] = q_elec_out / max(V_t, 0.01)
     elseif Ref_Flag == 1 && PF_Flag == 0 && V_Flag == 0
         # TODO: Fix and debug this case when Q_Flag = 1
-        K_i = PSY.get_K_i(reactive_power_control)
-        K_qi = PSY.get_K_qi(reactive_power_control)
-        K_c = PSY.get_K_c(reactive_power_control)
-        R_c = PSY.get_R_c(reactive_power_control)
-        X_c = PSY.get_R_c(reactive_power_control)
         VC_Flag = PSY.get_VC_Flag(reactive_power_control)
         V_reg = sqrt(Vr_filter^2 + Vi_filter^2)
         # Compute input to the compensated voltage filter

--- a/src/models/branch.jl
+++ b/src/models/branch.jl
@@ -1,6 +1,7 @@
 function branch!(
     device_states::AbstractArray{T},
     output_ode::AbstractArray{T},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     voltage_r_from::T,
     voltage_i_from::T,
     voltage_r_to::T,
@@ -15,6 +16,7 @@ function branch!(
     mdl_branch_ode!(
         device_states,
         output_ode,
+        device_parameters,
         voltage_r_from,
         voltage_i_from,
         voltage_r_to,
@@ -32,6 +34,7 @@ end
 function branch!(
     device_states::AbstractArray{T},
     output_ode::AbstractArray{T},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     voltage_r_from::T,
     voltage_i_from::T,
     voltage_r_to::T,
@@ -46,6 +49,7 @@ function branch!(
     mdl_transformer_Lshape_ode!(
         device_states,
         output_ode,
+        device_parameters,
         voltage_r_from,
         voltage_i_from,
         voltage_r_to,

--- a/src/models/dynline_model.jl
+++ b/src/models/dynline_model.jl
@@ -1,6 +1,7 @@
 function mdl_branch_ode!(
     device_states::AbstractArray{T},
     output_ode::AbstractArray{T},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     voltage_r_from::T,
     voltage_i_from::T,
     voltage_r_to::T,
@@ -11,8 +12,7 @@ function mdl_branch_ode!(
     current_i_to::AbstractArray{T},
     branch::BranchWrapper,
 ) where {T <: ACCEPTED_REAL_TYPES}
-    L = PSY.get_x(branch)
-    R = PSY.get_r(branch)
+    R, L = device_parameters
     ω_b = get_system_base_frequency(branch) * 2 * π
 
     Il_r = device_states[1]
@@ -30,6 +30,7 @@ end
 function mdl_transformer_Lshape_ode!(
     device_states::AbstractArray{T},
     output_ode::AbstractArray{T},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     voltage_r_from::T,
     voltage_i_from::T,
     voltage_r_to::T,

--- a/src/models/generator_models/machine_models.jl
+++ b/src/models/generator_models/machine_models.jl
@@ -13,6 +13,7 @@ Refer to Power System Modelling and Scripting by F. Milano for the equations
 function mdl_machine_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_r::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_i::AbstractArray{<:ACCEPTED_REAL_TYPES},
@@ -28,10 +29,9 @@ function mdl_machine_ode!(
     V_tI = inner_vars[VI_gen_var]
 
     #Get parameters
-    machine = PSY.get_machine(dynamic_device)
-    R = PSY.get_R(machine)
-    Xd_p = PSY.get_Xd_p(machine)
-    eq_p = PSY.get_eq_p(machine)
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.BaseMachine)
+    internal_params = @view device_parameters[local_ix_params]
+    R, Xd_p, eq_p = internal_params
     basepower = PSY.get_base_power(dynamic_device)
 
     #RI to dq transformation
@@ -62,6 +62,7 @@ Refer to Power System Modelling and Scripting by F. Milano for the equations
 function mdl_machine_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_r::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_i::AbstractArray{<:ACCEPTED_REAL_TYPES},
@@ -87,14 +88,10 @@ function mdl_machine_ode!(
     Vf = inner_vars[Vf_var]
 
     #Get parameters
-    machine = PSY.get_machine(dynamic_device)
-    R = PSY.get_R(machine)
-    Xd = PSY.get_Xd(machine)
-    Xq = PSY.get_Xq(machine)
-    Xd_p = PSY.get_Xd_p(machine)
-    Xq_p = PSY.get_Xq_p(machine)
-    Td0_p = PSY.get_Td0_p(machine)
-    Tq0_p = PSY.get_Tq0_p(machine)
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.OneDOneQMachine)
+    internal_params = @view device_parameters[local_ix_params]
+    R, Xd, Xq, Xd_p, Xq_p, Td0_p, Tq0_p = internal_params
+
     basepower = PSY.get_base_power(dynamic_device)
 
     #RI to dq transformation
@@ -129,6 +126,7 @@ Refer to Power System Modelling and Scripting by F. Milano for the equations
 function mdl_machine_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_r::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_i::AbstractArray{<:ACCEPTED_REAL_TYPES},
@@ -219,6 +217,7 @@ Refer to Power System Modelling and Scripting by F. Milano for the equations
 function mdl_machine_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_r::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_i::AbstractArray{<:ACCEPTED_REAL_TYPES},
@@ -250,21 +249,10 @@ function mdl_machine_ode!(
     Vf = inner_vars[Vf_var]
 
     #Get parameters
-    machine = PSY.get_machine(dynamic_device)
-    R = PSY.get_R(machine)
-    Xd = PSY.get_Xd(machine)
-    Xq = PSY.get_Xq(machine)
-    Xd_p = PSY.get_Xd_p(machine)
-    Xq_p = PSY.get_Xq_p(machine)
-    Xd_pp = PSY.get_Xd_pp(machine)
-    Xq_pp = PSY.get_Xq_pp(machine)
-    Td0_p = PSY.get_Td0_p(machine)
-    Tq0_p = PSY.get_Tq0_p(machine)
-    Td0_pp = PSY.get_Td0_pp(machine)
-    Tq0_pp = PSY.get_Tq0_pp(machine)
-    T_AA = PSY.get_T_AA(machine)
-    γd = PSY.get_γd(machine)
-    γq = PSY.get_γq(machine)
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.MarconatoMachine)
+    internal_params = @view device_parameters[local_ix_params]
+    R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, T_AA, γd, γq =
+        internal_params
     basepower = PSY.get_base_power(dynamic_device)
 
     #RI to dq transformation
@@ -305,6 +293,7 @@ Refer to Power System Modelling and Scripting by F. Milano for the equations
 function mdl_machine_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_r::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_i::AbstractArray{<:ACCEPTED_REAL_TYPES},
@@ -390,6 +379,7 @@ Refer to Power System Modelling and Scripting by F. Milano for the equations
 function mdl_machine_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_r::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_i::AbstractArray{<:ACCEPTED_REAL_TYPES},
@@ -423,18 +413,19 @@ function mdl_machine_ode!(
     Vf = inner_vars[Vf_var]
 
     #Get parameters
-    machine = PSY.get_machine(dynamic_device)
-    R = PSY.get_R(machine)
-    Xd = PSY.get_Xd(machine)
-    Xq = PSY.get_Xq(machine)
-    Xd_p = PSY.get_Xd_p(machine)
-    Xq_p = PSY.get_Xq_p(machine)
-    Xd_pp = PSY.get_Xd_pp(machine)
-    Xq_pp = PSY.get_Xq_pp(machine)
-    Td0_p = PSY.get_Td0_p(machine)
-    Tq0_p = PSY.get_Tq0_p(machine)
-    Td0_pp = PSY.get_Td0_pp(machine)
-    Tq0_pp = PSY.get_Tq0_pp(machine)
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.AndersonFouadMachine)
+    internal_params = @view device_parameters[local_ix_params]
+    R,
+    Xd,
+    Xq,
+    Xd_p,
+    Xq_p,
+    Xd_pp,
+    Xq_pp,
+    Td0_p,
+    Tq0_p,
+    Td0_pp,
+    Tq0_pp = internal_params
     basepower = PSY.get_base_power(dynamic_device)
 
     #RI to dq transformation
@@ -473,6 +464,7 @@ Refer to Power System Modelling and Scripting by F. Milano for the equations
 function mdl_machine_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_r::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_i::AbstractArray{<:ACCEPTED_REAL_TYPES},
@@ -548,6 +540,7 @@ end
 function mdl_machine_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_r::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_i::AbstractArray{<:ACCEPTED_REAL_TYPES},
@@ -583,23 +576,25 @@ function mdl_machine_ode!(
     Vf = inner_vars[Vf_var] #E_fd: Field voltage
 
     #Get parameters
-    R = PSY.get_R(machine)
-    Td0_p = PSY.get_Td0_p(machine)
-    Td0_pp = PSY.get_Td0_pp(machine)
-    Tq0_p = PSY.get_Tq0_p(machine)
-    Tq0_pp = PSY.get_Tq0_pp(machine)
-    Xd = PSY.get_Xd(machine)
-    Xq = PSY.get_Xq(machine)
-    Xd_p = PSY.get_Xd_p(machine)
-    Xq_p = PSY.get_Xq_p(machine)
-    Xd_pp = PSY.get_Xd_pp(machine)
+    local_ix_params = get_local_parameter_ix(dynamic_device, typeof(machine))
+    internal_params = @view device_parameters[local_ix_params]
+    R,
+    Td0_p,
+    Td0_pp,
+    Tq0_p,
+    Tq0_pp,
+    Xd,
+    Xq,
+    Xd_p,
+    Xq_p,
+    Xd_pp,
+    Xl,
+    γ_d1,
+    γ_q1,
+    γ_d2,
+    γ_q2,
+    γ_qd = internal_params
     Xq_pp = Xd_pp
-    Xl = PSY.get_Xl(machine)
-    γ_d1 = PSY.get_γ_d1(machine)
-    γ_q1 = PSY.get_γ_q1(machine)
-    γ_d2 = PSY.get_γ_d2(machine)
-    γ_q2 = PSY.get_γ_q2(machine)
-    γ_qd = PSY.get_γ_qd(machine)
     basepower = PSY.get_base_power(dynamic_device)
 
     #RI to dq transformation
@@ -644,6 +639,7 @@ end
 function mdl_machine_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_r::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_i::AbstractArray{<:ACCEPTED_REAL_TYPES},
@@ -674,19 +670,21 @@ function mdl_machine_ode!(
     Vf = inner_vars[Vf_var] #E_fd: Field voltage
 
     #Get parameters
-    R = PSY.get_R(machine)
-    Td0_p = PSY.get_Td0_p(machine)
-    Td0_pp = PSY.get_Td0_pp(machine)
-    Tq0_pp = PSY.get_Tq0_pp(machine)
-    Xd = PSY.get_Xd(machine)
-    Xq = PSY.get_Xq(machine)
-    Xd_p = PSY.get_Xd_p(machine)
-    Xd_pp = PSY.get_Xd_pp(machine)
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.SalientPoleQuadratic)
+    internal_params = @view device_parameters[local_ix_params]
+    R,
+    Td0_p,
+    Td0_pp,
+    Tq0_pp,
+    Xd,
+    Xq,
+    Xd_p,
+    Xd_pp,
+    Xl,
+    γ_d1,
+    γ_q1,
+    γ_d2 = internal_params
     Xq_pp = Xd_pp
-    Xl = PSY.get_Xl(machine)
-    γ_d1 = PSY.get_γ_d1(machine)
-    γ_q1 = PSY.get_γ_q1(machine)
-    γ_d2 = PSY.get_γ_d2(machine)
     basepower = PSY.get_base_power(dynamic_device)
 
     #RI to dq transformation
@@ -725,6 +723,7 @@ end
 function mdl_machine_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_r::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_i::AbstractArray{<:ACCEPTED_REAL_TYPES},
@@ -755,19 +754,21 @@ function mdl_machine_ode!(
     Vf = inner_vars[Vf_var] #E_fd: Field voltage
 
     #Get parameters
-    R = PSY.get_R(machine)
-    Td0_p = PSY.get_Td0_p(machine)
-    Td0_pp = PSY.get_Td0_pp(machine)
-    Tq0_pp = PSY.get_Tq0_pp(machine)
-    Xd = PSY.get_Xd(machine)
-    Xq = PSY.get_Xq(machine)
-    Xd_p = PSY.get_Xd_p(machine)
-    Xd_pp = PSY.get_Xd_pp(machine)
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.SalientPoleExponential)
+    internal_params = @view device_parameters[local_ix_params]
+    R,
+    Td0_p,
+    Td0_pp,
+    Tq0_pp,
+    Xd,
+    Xq,
+    Xd_p,
+    Xd_pp,
+    Xl,
+    γ_d1,
+    γ_q1,
+    γ_d2 = internal_params
     Xq_pp = Xd_pp
-    Xl = PSY.get_Xl(machine)
-    γ_d1 = PSY.get_γ_d1(machine)
-    γ_q1 = PSY.get_γ_q1(machine)
-    γ_d2 = PSY.get_γ_d2(machine)
     γ_qd = (Xq - Xl) / (Xd - Xl)
     basepower = PSY.get_base_power(dynamic_device)
 
@@ -816,6 +817,7 @@ or Power System Stability and Control by P. Kundur, for the equations
 
 function mdl_machine_ode!(
     device_states,
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode,
 inner_vars,
 current_r::AbstractArray{<:ACCEPTED_REAL_TYPES},

--- a/src/models/generator_models/pss_models.jl
+++ b/src/models/generator_models/pss_models.jl
@@ -115,13 +115,17 @@ end
 function mdl_pss_ode!(
     ::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ω_sys::ACCEPTED_REAL_TYPES,
     dynamic_device::DynamicWrapper{PSY.DynamicGenerator{M, S, A, TG, PSY.PSSFixed}},
 ) where {M <: PSY.Machine, S <: PSY.Shaft, A <: PSY.AVR, TG <: PSY.TurbineGov}
 
     #Update V_pss on inner vars
-    inner_vars[V_pss_var] = PSY.get_V_pss(PSY.get_pss(dynamic_device))
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.PSSFixed)
+    internal_params = @view device_parameters[local_ix_params]
+    V_pss = internal_params[1]
+    inner_vars[V_pss_var] = V_pss
 
     return
 end
@@ -129,6 +133,7 @@ end
 function mdl_pss_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ω_sys::ACCEPTED_REAL_TYPES,
     dynamic_device::DynamicWrapper{PSY.DynamicGenerator{M, S, A, TG, PSY.IEEEST}},
@@ -226,13 +231,11 @@ end
 function mdl_pss_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ω_sys::ACCEPTED_REAL_TYPES,
     dynamic_device::DynamicWrapper{PSY.DynamicGenerator{M, S, A, TG, PSY.STAB1}},
 ) where {M <: PSY.Machine, S <: PSY.Shaft, A <: PSY.AVR, TG <: PSY.TurbineGov}
-
-    #Get Signal Input Integer
-    pss = PSY.get_pss(dynamic_device)
 
     # Get Input Signal - only speed deviation for STAB1
     external_ix = get_input_port_ix(dynamic_device, PSY.STAB1)
@@ -249,13 +252,15 @@ function mdl_pss_ode!(
     x_p3 = internal_states[3] # state for Lead Lag 2
 
     # Get Parameters
-    KT = PSY.get_KT(pss)
-    T = PSY.get_T(pss)
-    T1T3 = PSY.get_T1T3(pss)
-    T3 = PSY.get_T3(pss)
-    T2T4 = PSY.get_T2T4(pss)
-    T4 = PSY.get_T4(pss)
-    H_lim = PSY.get_H_lim(pss)
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.STAB1)
+    internal_params = @view device_parameters[local_ix_params]
+    KT,
+    T,
+    T1T3,
+    T3,
+    T2T4,
+    T4,
+    H_lim = internal_params
 
     K = T * KT
     T1 = T3 * T1T3
@@ -281,6 +286,7 @@ end
 function mdl_pss_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ω_sys::ACCEPTED_REAL_TYPES,
     dynamic_device::DynamicWrapper{PSY.DynamicGenerator{M, S, A, TG, PSY.PSS2A}},
@@ -449,6 +455,7 @@ end
 function mdl_pss_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ω_sys::ACCEPTED_REAL_TYPES,
     dynamic_device::DynamicWrapper{PSY.DynamicGenerator{M, S, A, TG, PSY.PSS2B}},
@@ -628,6 +635,7 @@ end
 function mdl_pss_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ω_sys::ACCEPTED_REAL_TYPES,
     dynamic_device::DynamicWrapper{PSY.DynamicGenerator{M, S, A, TG, PSY.PSS2C}},

--- a/src/models/generator_models/shaft_models.jl
+++ b/src/models/generator_models/shaft_models.jl
@@ -9,6 +9,7 @@ end
 function mdl_shaft_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ω_sys::ACCEPTED_REAL_TYPES,
     dynamic_device::DynamicWrapper{PSY.DynamicGenerator{M, PSY.SingleMass, A, TG, P}},
@@ -26,9 +27,9 @@ function mdl_shaft_ode!(
     τm = inner_vars[τm_var]
 
     #Get parameters
-    shaft = PSY.get_shaft(dynamic_device)
-    H = PSY.get_H(shaft)
-    D = PSY.get_D(shaft)
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.SingleMass)
+    internal_params = @view device_parameters[local_ix_params]
+    H, D = internal_params
 
     #Compute 2 states ODEs
     output_ode[local_ix[1]] = 2 * π * f0 * (ω - ω_sys)                    #15.5
@@ -40,6 +41,7 @@ end
 function mdl_shaft_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ω_sys::ACCEPTED_REAL_TYPES,
     dynamic_device::DynamicWrapper{PSY.DynamicGenerator{M, PSY.FiveMassShaft, A, TG, P}},
@@ -67,25 +69,26 @@ function mdl_shaft_ode!(
     τm = inner_vars[τm_var]
 
     #Get parameters
-    shaft = PSY.get_shaft(dynamic_device)
-    H = PSY.get_H(shaft)
-    H_hp = PSY.get_H_hp(shaft)
-    H_ip = PSY.get_H_ip(shaft)
-    H_lp = PSY.get_H_lp(shaft)
-    H_ex = PSY.get_H_ex(shaft)
-    D = PSY.get_D(shaft)
-    D_hp = PSY.get_D_hp(shaft)
-    D_ip = PSY.get_D_ip(shaft)
-    D_lp = PSY.get_D_lp(shaft)
-    D_ex = PSY.get_D_ex(shaft)
-    D_12 = PSY.get_D_12(shaft)
-    D_23 = PSY.get_D_23(shaft)
-    D_34 = PSY.get_D_34(shaft)
-    D_45 = PSY.get_D_45(shaft)
-    K_hp = PSY.get_K_hp(shaft)
-    K_ip = PSY.get_K_ip(shaft)
-    K_lp = PSY.get_K_lp(shaft)
-    K_ex = PSY.get_K_ex(shaft)
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.SingleMass)
+    internal_params = @view device_parameters[local_ix_params]
+    H,
+    H_hp,
+    H_ip,
+    H_lp,
+    H_ex,
+    D,
+    D_hp,
+    D_ip,
+    D_lp,
+    D_ex,
+    D_12,
+    D_23,
+    D_34,
+    D_45,
+    K_hp,
+    K_ip,
+    K_lp,
+    K_ex = internal_params
 
     #Compute 10 states ODEs #15.51
     output_ode[local_ix[1]] = 2.0 * π * f0 * (ω - ω_sys)

--- a/src/models/generator_models/tg_models.jl
+++ b/src/models/generator_models/tg_models.jl
@@ -19,29 +19,33 @@ end
 function mdl_tg_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ω_sys::ACCEPTED_REAL_TYPES,
     device::DynamicWrapper{PSY.DynamicGenerator{M, S, A, PSY.TGFixed, P}},
 ) where {M <: PSY.Machine, S <: PSY.Shaft, A <: PSY.AVR, P <: PSY.PSS}
 
     #Update inner vars
-    P_ref = get_P_ref(device)
-    inner_vars[τm_var] = P_ref * PSY.get_efficiency(PSY.get_prime_mover(device))
-
+    local_ix_params = get_local_parameter_ix(device, PSY.TGFixed)
+    internal_params = @view device_parameters[local_ix_params]
+    efficiency = internal_params[1]
+    P_ref = device_parameters[P_ref_ix]
+    inner_vars[τm_var] = P_ref * efficiency
     return
 end
 
 function mdl_tg_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ω_sys::ACCEPTED_REAL_TYPES,
     device::DynamicWrapper{PSY.DynamicGenerator{M, S, A, PSY.TGTypeI, P}},
 ) where {M <: PSY.Machine, S <: PSY.Shaft, A <: PSY.AVR, P <: PSY.PSS}
 
     #Obtain references
-    ω_ref = get_ω_ref(device)
-    P_ref = get_P_ref(device)
+    ω_ref = device_parameters[ω_ref_ix]
+    P_ref = device_parameters[P_ref_ix]
 
     #Obtain indices for component w/r to device
     local_ix = get_local_state_ix(device, PSY.TGTypeI)
@@ -57,14 +61,10 @@ function mdl_tg_ode!(
     ω = @view device_states[external_ix]
 
     #Get Parameters
-    tg = PSY.get_prime_mover(device)
-    inv_R = PSY.get_R(tg) < eps() ? 0.0 : (1.0 / PSY.get_R(tg))
-    Ts = PSY.get_Ts(tg)
-    Tc = PSY.get_Tc(tg)
-    T3 = PSY.get_T3(tg)
-    T4 = PSY.get_T4(tg)
-    T5 = PSY.get_T5(tg)
-    V_min, V_max = PSY.get_valve_position_limits(tg)
+    local_ix_params = get_local_parameter_ix(device, PSY.TGTypeI)
+    internal_params = @view device_parameters[local_ix_params]
+    R, Ts, Tc, T3, T4, T5, V_min, V_max = internal_params
+    inv_R = R < eps() ? 0.0 : (1.0 / R)
 
     #Compute auxiliary parameters
     P_in_sat = clamp(P_ref + inv_R * (ω_ref - ω[1]), V_min, V_max)
@@ -88,14 +88,15 @@ end
 function mdl_tg_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ω_sys::ACCEPTED_REAL_TYPES,
     device::DynamicWrapper{PSY.DynamicGenerator{M, S, A, PSY.TGTypeII, P}},
 ) where {M <: PSY.Machine, S <: PSY.Shaft, A <: PSY.AVR, P <: PSY.PSS}
 
     #Obtain references
-    ω_ref = get_ω_ref(device)
-    P_ref = get_P_ref(device)
+    ω_ref = device_parameters[ω_ref_ix]
+    P_ref = device_parameters[P_ref_ix]
 
     #Obtain indices for component w/r to device
     local_ix = get_local_state_ix(device, PSY.TGTypeII)
@@ -108,11 +109,11 @@ function mdl_tg_ode!(
     external_ix = get_input_port_ix(device, PSY.TGTypeII)
     ω = @view device_states[external_ix]
 
-    #Get Parameters
-    tg = PSY.get_prime_mover(device)
-    inv_R = PSY.get_R(tg) < eps() ? 0.0 : (1.0 / PSY.get_R(tg))
-    T1 = PSY.get_T1(tg)
-    T2 = PSY.get_T2(tg)
+    #Get parameters
+    local_ix_params = get_local_parameter_ix(device, PSY.TGTypeII)
+    internal_params = @view device_parameters[local_ix_params]
+    R, T1, T2 = internal_params
+    inv_R = R < eps() ? 0.0 : (1.0 / R)
 
     #Compute block derivatives
     y_ll1, dxg_dt = lead_lag(inv_R * (ω_ref - ω[1]), xg, 1.0, T1, T2)
@@ -130,6 +131,7 @@ end
 function mdl_tg_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ω_sys::ACCEPTED_REAL_TYPES,
     device::DynamicWrapper{PSY.DynamicGenerator{M, S, A, PSY.SteamTurbineGov1, P}},
@@ -138,7 +140,7 @@ function mdl_tg_ode!(
     #Obtain TG
     tg = PSY.get_prime_mover(device)
     #Obtain references
-    P_ref = get_P_ref(device)
+    P_ref = device_parameters[P_ref_ix]
 
     #Obtain indices for component w/r to device
     local_ix = get_local_state_ix(device, typeof(tg))
@@ -153,13 +155,16 @@ function mdl_tg_ode!(
     ω = @view device_states[external_ix]
 
     #Get Parameters
-    tg = PSY.get_prime_mover(device)
-    inv_R = PSY.get_R(tg) < eps() ? 0.0 : (1.0 / PSY.get_R(tg))
-    T1 = PSY.get_T1(tg)
-    T2 = PSY.get_T2(tg)
-    V_min, V_max = PSY.get_valve_position_limits(tg)
-    T3 = PSY.get_T3(tg)
-    D_T = PSY.get_D_T(tg)
+    local_ix_params = get_local_parameter_ix(device, PSY.SteamTurbineGov1)
+    internal_params = @view device_parameters[local_ix_params]
+    R,
+    T1,
+    V_min,
+    V_max,
+    T2,
+    T3,
+    D_T = internal_params
+    inv_R = R < eps() ? 0.0 : (1.0 / R)
 
     #Compute auxiliary parameters
     ref_in = inv_R * (P_ref - (ω[1] - 1.0))
@@ -182,13 +187,14 @@ end
 function mdl_tg_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ω_sys::ACCEPTED_REAL_TYPES,
     device::DynamicWrapper{PSY.DynamicGenerator{M, S, A, PSY.GasTG, P}},
 ) where {M <: PSY.Machine, S <: PSY.Shaft, A <: PSY.AVR, P <: PSY.PSS}
 
     #Obtain references
-    P_ref = get_P_ref(device)
+    P_ref = device_parameters[P_ref_ix]
 
     #Obtain indices for component w/r to device
     local_ix = get_local_state_ix(device, PSY.GasTG)
@@ -204,18 +210,13 @@ function mdl_tg_ode!(
     ω = @view device_states[external_ix]
 
     #Get Parameters
-    tg = PSY.get_prime_mover(device)
-    inv_R = PSY.get_R(tg) < eps() ? 0.0 : (1.0 / PSY.get_R(tg))
-    T1 = PSY.get_T1(tg)
-    T2 = PSY.get_T2(tg)
-    T3 = PSY.get_T3(tg)
-    D_turb = PSY.get_D_turb(tg)
-    AT = PSY.get_AT(tg)
-    KT = PSY.get_Kt(tg)
-    V_min, V_max = PSY.get_V_lim(tg)
+    local_ix_params = get_local_parameter_ix(device, PSY.GasTG)
+    internal_params = @view device_parameters[local_ix_params]
+    R, T1, T2, T3, AT, Kt, V_min, V_max, D_turb = internal_params
+    inv_R = R < eps() ? 0.0 : (1.0 / R)
 
     #Compute auxiliary parameters
-    x_in = min((P_ref - inv_R * (ω[1] - 1.0)), (AT + KT * (AT - x_g3)))
+    x_in = min((P_ref - inv_R * (ω[1] - 1.0)), (AT + Kt * (AT - x_g3)))
 
     #Compute block derivatives
     x_g1_sat, dxg1_dt = low_pass_nonwindup(x_in, x_g1, 1.0, T1, V_min, V_max)
@@ -239,14 +240,15 @@ end
 function mdl_tg_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ω_sys::ACCEPTED_REAL_TYPES,
     device::DynamicWrapper{PSY.DynamicGenerator{M, S, A, PSY.HydroTurbineGov, P}},
 ) where {M <: PSY.Machine, S <: PSY.Shaft, A <: PSY.AVR, P <: PSY.PSS}
 
     #Obtain references
-    P_ref = get_P_ref(device)
-    ω_ref = get_ω_ref(device)
+    P_ref = device_parameters[P_ref_ix]
+    ω_ref = device_parameters[ω_ref_ix]
 
     #Obtain indices for component w/r to device
     local_ix = get_local_state_ix(device, PSY.HydroTurbineGov)
@@ -264,19 +266,20 @@ function mdl_tg_ode!(
     Δω = ω - ω_ref
 
     #Get Parameters
-    tg = PSY.get_prime_mover(device)
-    R = PSY.get_R(tg)
-    r = PSY.get_r(tg)
-    Tr = PSY.get_Tr(tg)
-    Tf = PSY.get_Tf(tg)
-    Tg = PSY.get_Tg(tg)
-
-    VELM = PSY.get_VELM(tg)
-    G_min, G_max = PSY.get_gate_position_limits(tg)
-    Tw = PSY.get_Tw(tg)
-    At = PSY.get_At(tg)
-    D_T = PSY.get_D_T(tg)
-    q_nl = PSY.get_q_nl(tg)
+    local_ix_params = get_local_parameter_ix(device, PSY.HydroTurbineGov)
+    internal_params = @view device_parameters[local_ix_params]
+    R,
+    r,
+    Tr,
+    Tf,
+    Tg,
+    VELM,
+    G_min,
+    G_max,
+    Tw,
+    At,
+    D_T,
+    q_nl = internal_params
 
     #Compute block derivatives
     c, dxg2_dt = pi_block_nonwindup(x_g1, x_g2, 1.0 / r, 1.0 / (r * Tr), G_min, G_max)

--- a/src/models/inverter_models/DCside_models.jl
+++ b/src/models/inverter_models/DCside_models.jl
@@ -9,6 +9,7 @@ end
 function mdl_DCside_ode!(
     ::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ω_sys::ACCEPTED_REAL_TYPES,
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     dynamic_device::DynamicWrapper{
@@ -22,7 +23,8 @@ function mdl_DCside_ode!(
     F <: PSY.Filter,
     L <: Union{Nothing, PSY.InverterLimiter},
 }
-
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.FixedDCSource)
+    internal_params = @view device_parameters[local_ix_params]
     #Update inner_vars
-    inner_vars[Vdc_var] = PSY.get_voltage(PSY.get_dc_source(dynamic_device))
+    inner_vars[Vdc_var] = internal_params[1]
 end

--- a/src/models/inverter_models/converter_models.jl
+++ b/src/models/inverter_models/converter_models.jl
@@ -9,6 +9,7 @@ end
 function mdl_converter_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     dynamic_device::DynamicWrapper{
         PSY.DynamicInverter{PSY.AverageConverter, O, IC, DC, P, F, L},
@@ -40,6 +41,7 @@ end
 function mdl_converter_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     dynamic_device::DynamicWrapper{
         PSY.DynamicInverter{
@@ -68,22 +70,28 @@ function mdl_converter_ode!(
     Iq_cmd = inner_vars[Iq_ic_var]
 
     #Get Converter parameters
+    local_ix_params =
+        get_local_parameter_ix(dynamic_device, PSY.RenewableEnergyConverterTypeA)
+    internal_params = @view device_parameters[local_ix_params]
+    T_g,
+    Rrpwr,
+    Brkpt,
+    Zerox,
+    Lvpl1,
+    Vo_lim,
+    Lv_pnt0,
+    Lv_pnt1,
+    Io_lim,
+    T_fltr,
+    K_hv,
+    Iqr_min,
+    Iqr_max,
+    Accel,
+    Q_ref,
+    R_source,
+    X_source = internal_params
     converter = PSY.get_converter(dynamic_device)
-    T_g = PSY.get_T_g(converter)
-    Rrpwr = PSY.get_Rrpwr(converter)
-    Brkpt = PSY.get_Brkpt(converter)
-    Zerox = PSY.get_Zerox(converter)
-    Lvpl1 = PSY.get_Lvpl1(converter)
-    Vo_lim = PSY.get_Vo_lim(converter)
-    Lv_pnt0, Lv_pnt1 = PSY.get_Lv_pnts(converter)
-    # Io_lim = PSY.get_Io_lim(converter)
-    T_fltr = PSY.get_T_fltr(converter)
-    K_hv = PSY.get_K_hv(converter)
-    Iqr_min, Iqr_max = PSY.get_Iqr_lims(converter)
     Lvpl_sw = PSY.get_Lvpl_sw(converter)
-    Q_ref = PSY.get_Q_ref(converter)
-    R_source = PSY.get_R_source(converter)
-    X_source = PSY.get_X_source(converter)
 
     #Obtain indices for component w/r to device
     local_ix = get_local_state_ix(dynamic_device, PSY.RenewableEnergyConverterTypeA)
@@ -173,6 +181,7 @@ end
 function mdl_converter_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     dynamic_device::DynamicWrapper{
         PSY.DynamicInverter{

--- a/src/models/inverter_models/filter_models.jl
+++ b/src/models/inverter_models/filter_models.jl
@@ -35,6 +35,7 @@ end
 function mdl_filter_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_r::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_i::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
@@ -59,14 +60,12 @@ function mdl_filter_ode!(
     Vi_cnv = inner_vars[Vi_cnv_var]
 
     #Get parameters
-    filter = PSY.get_filter(dynamic_device)
     f0 = get_system_base_frequency(dynamic_device)
     ωb = 2 * pi * f0
-    lf = PSY.get_lf(filter)
-    rf = PSY.get_rf(filter)
-    cf = PSY.get_cf(filter)
-    lg = PSY.get_lg(filter)
-    rg = PSY.get_rg(filter)
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.LCLFilter)
+    internal_params = @view device_parameters[local_ix_params]
+    lf, rf, cf, lg, rg = internal_params
+
     basepower = PSY.get_base_power(dynamic_device)
     sys_Sbase = get_system_base_power(dynamic_device)
 
@@ -117,6 +116,7 @@ end
 function mdl_filter_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_r::AbstractArray{<:ACCEPTED_REAL_TYPES},
     current_i::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
@@ -136,9 +136,9 @@ function mdl_filter_ode!(
     ratio_power = basepower / sys_Sbase
 
     #Obtain parameters
-    filt = PSY.get_filter(dynamic_device)
-    rf = PSY.get_rf(filt)
-    lf = PSY.get_lf(filt)
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.RLFilter)
+    internal_params = @view device_parameters[local_ix_params]
+    rf, lf = internal_params
 
     Vr_cnv = inner_vars[Vr_cnv_var]
     Vi_cnv = inner_vars[Vi_cnv_var]

--- a/src/models/inverter_models/frequency_estimator_models.jl
+++ b/src/models/inverter_models/frequency_estimator_models.jl
@@ -9,6 +9,7 @@ end
 function mdl_freq_estimator_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ω_sys::ACCEPTED_REAL_TYPES,
     dynamic_device::DynamicWrapper{PSY.DynamicInverter{C, O, IC, DC, PSY.KauraPLL, F, L}},
@@ -27,10 +28,10 @@ function mdl_freq_estimator_ode!(
     Vi_filter = device_states[external_ix[2]]
 
     #Get parameters
-    pll_control = PSY.get_freq_estimator(dynamic_device)
-    ω_lp = PSY.get_ω_lp(pll_control)
-    kp_pll = PSY.get_kp_pll(pll_control)
-    ki_pll = PSY.get_ki_pll(pll_control)
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.KauraPLL)
+    internal_params = @view device_parameters[local_ix_params]
+    ω_lp, kp_pll, ki_pll = internal_params
+
     f0 = get_system_base_frequency(dynamic_device)
     ωb = 2.0 * pi * f0
 
@@ -73,6 +74,7 @@ end
 function mdl_freq_estimator_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ω_sys::ACCEPTED_REAL_TYPES,
     dynamic_device::DynamicWrapper{
@@ -134,6 +136,7 @@ end
 function mdl_freq_estimator_ode!(
     ::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ω_sys::ACCEPTED_REAL_TYPES,
     dynamic_device::DynamicWrapper{
@@ -147,10 +150,10 @@ function mdl_freq_estimator_ode!(
     F <: PSY.Filter,
     L <: Union{Nothing, PSY.InverterLimiter},
 }
-
     #Get parameters
-    pll_control = PSY.get_freq_estimator(dynamic_device)
-    frequency = PSY.get_frequency(pll_control)
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.FixedFrequency)
+    internal_params = @view device_parameters[local_ix_params]
+    frequency = internal_params[1]
 
     #Update inner_vars
     #PLL frequency

--- a/src/models/inverter_models/inner_control_models.jl
+++ b/src/models/inverter_models/inner_control_models.jl
@@ -31,6 +31,7 @@ end
 function _mdl_ode_RE_inner_controller_B!(
     inner_controller_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_controller_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    inner_controller_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ::Val{0},
     inner_control::PSY.RECurrentControlB,
     dynamic_device::DynamicWrapper{
@@ -52,12 +53,19 @@ function _mdl_ode_RE_inner_controller_B!(
 
     #Get Current Controller parameters
     PQ_Flag = PSY.get_PQ_Flag(inner_control)
-    dbd1, dbd2 = PSY.get_dbd_pnts(inner_control)
-    K_qv = PSY.get_K_qv(inner_control)
-    I_ql1, I_qh1 = PSY.get_Iqinj_lim(inner_control)
-    V_ref0 = PSY.get_V_ref0(inner_control)
-    T_rv = PSY.get_T_rv(inner_control)
-    T_iq = PSY.get_T_iq(inner_control)
+    Vdip_min,
+    Vdip_max,
+    T_rv,
+    dbd1,
+    dbd2,
+    K_qv,
+    I_ql1,
+    I_qh1,
+    V_ref0,
+    K_vp,
+    K_vi,
+    T_iq,
+    I_max = inner_controller_parameters
 
     #Read local states
     Vt_filt = inner_controller_states[1]
@@ -86,6 +94,7 @@ end
 function _mdl_ode_RE_inner_controller_B!(
     inner_controller_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_controller_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    inner_controller_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     ::Val{1},
     inner_control::PSY.RECurrentControlB,
     dynamic_device::DynamicWrapper{
@@ -107,13 +116,19 @@ function _mdl_ode_RE_inner_controller_B!(
 
     #Get Current Controller parameters
     PQ_Flag = PSY.get_PQ_Flag(inner_control)
-    K_vp = PSY.get_K_vp(inner_control)
-    K_vi = PSY.get_K_vi(inner_control)
-    V_ref0 = PSY.get_V_ref0(inner_control)
-    dbd1, dbd2 = PSY.get_dbd_pnts(inner_control)
-    K_qv = PSY.get_K_qv(inner_control)
-    I_ql1, I_qh1 = PSY.get_Iqinj_lim(inner_control)
-    T_rv = PSY.get_T_rv(inner_control)
+    Vdip_min,
+    Vdip_max,
+    T_rv,
+    dbd1,
+    dbd2,
+    K_qv,
+    I_ql1,
+    I_qh1,
+    V_ref0,
+    K_vp,
+    K_vi,
+    T_iq,
+    I_max = inner_controller_parameters
 
     #Read local states
     Vt_filt = inner_controller_states[1]
@@ -149,16 +164,16 @@ end
 function mdl_inner_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     dynamic_device::DynamicWrapper{
-        PSY.DynamicInverter{C, O, PSY.VoltageModeControl, DC, P, F, L},
+        PSY.DynamicInverter{C, O, PSY.VoltageModeControl, DC, P, PSY.LCLFilter, L},
     },
 ) where {
     C <: PSY.Converter,
     O <: PSY.OuterControl,
     DC <: PSY.DCSource,
     P <: PSY.FrequencyEstimator,
-    F <: PSY.Filter,
     L <: Union{Nothing, PSY.InverterLimiter},
 }
 
@@ -178,22 +193,15 @@ function mdl_inner_ode!(
     Vdc = inner_vars[Vdc_var]
 
     #Get Voltage Controller parameters
-    inner_control = PSY.get_inner_control(dynamic_device)
     filter = PSY.get_filter(dynamic_device)
-    kpv = PSY.get_kpv(inner_control)
-    kiv = PSY.get_kiv(inner_control)
-    kffi = PSY.get_kffi(inner_control)
-    cf = PSY.get_cf(filter)
-    rv = PSY.get_rv(inner_control)
-    lv = PSY.get_lv(inner_control)
+    filter_ix_params = get_local_parameter_ix(dynamic_device, typeof(filter))
+    filter_params = @view device_parameters[filter_ix_params]
+    cf = filter_params[3]
+    lf = filter_params[1]
 
-    #Get Current Controller parameters
-    kpc = PSY.get_kpc(inner_control)
-    kic = PSY.get_kic(inner_control)
-    kffv = PSY.get_kffv(inner_control)
-    lf = PSY.get_lf(filter)
-    ωad = PSY.get_ωad(inner_control)
-    kad = PSY.get_kad(inner_control)
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.VoltageModeControl)
+    internal_params = @view device_parameters[local_ix_params]
+    kpv, kiv, kffv, rv, lv, kpc, kic, kffi, ωad, kad = internal_params
 
     #Obtain indices for component w/r to device
     local_ix = get_local_state_ix(dynamic_device, PSY.VoltageModeControl)
@@ -259,6 +267,7 @@ end
 function mdl_inner_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     dynamic_device::DynamicWrapper{
         PSY.DynamicInverter{C, O, PSY.CurrentModeControl, DC, P, F, L},
@@ -331,6 +340,7 @@ end
 function mdl_inner_ode!(
     device_states::AbstractArray{<:ACCEPTED_REAL_TYPES},
     output_ode::AbstractArray{<:ACCEPTED_REAL_TYPES},
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     inner_vars::AbstractArray{<:ACCEPTED_REAL_TYPES},
     dynamic_device::DynamicWrapper{
         PSY.DynamicInverter{C, O, PSY.RECurrentControlB, DC, P, F, L},
@@ -349,16 +359,18 @@ function mdl_inner_ode!(
 
     #Obtain indices for component w/r to device
     local_ix = get_local_state_ix(dynamic_device, PSY.RECurrentControlB)
+    local_ix_params = get_local_parameter_ix(dynamic_device, PSY.RECurrentControlB)
     #Define internal states for Inner Control
     internal_states = @view device_states[local_ix]
     internal_ode = @view output_ode[local_ix]
-
+    internal_parameters = @view device_parameters[local_ix_params]
     # TODO: Voltage Dip Freeze logic
 
     #Dispatch inner controller ODE calculation
     _mdl_ode_RE_inner_controller_B!(
         internal_ode,
         internal_states,
+        internal_parameters,
         Val(Q_Flag),
         inner_control,
         dynamic_device,

--- a/src/models/load_models.jl
+++ b/src/models/load_models.jl
@@ -37,13 +37,16 @@ Ii_im  = V_i * P0 * (V^(α - 2) / V0^α) - V_r * Q0 * (V^(β - 2)/ V0^β)
 
 """
 function mdl_zip_load!(
+    device_parameters::AbstractArray{<:ACCEPTED_REAL_TYPES},
     voltage_r::T,
     voltage_i::T,
     current_r::AbstractArray{T},
     current_i::AbstractArray{T},
     wrapper::StaticLoadWrapper,
 ) where {T <: ACCEPTED_REAL_TYPES}
-    # Read power flow voltages
+    # Load device parameters
+    _, _, P_power, P_current, P_impedance, Q_power, Q_current, Q_impedance =
+        device_parameters
     #V0_mag_inv = 1.0 / get_V_ref(wrapper)
     V0_mag_inv = 1.0 / PSY.get_magnitude(PSY.get_bus(wrapper))
     V0_mag_sq_inv = V0_mag_inv^2
@@ -52,13 +55,6 @@ function mdl_zip_load!(
     V_mag_inv = 1.0 / V_mag
     V_mag_sq_inv = V_mag_inv^2
 
-    # Load device parameters
-    P_power = get_P_power(wrapper)
-    P_current = get_P_current(wrapper)
-    P_impedance = get_P_impedance(wrapper)
-    Q_power = get_Q_power(wrapper)
-    Q_current = get_Q_current(wrapper)
-    Q_impedance = get_Q_impedance(wrapper)
     exp_params = get_exp_params(wrapper)
     Ir_exp = zero(T)
     Ii_exp = zero(T)

--- a/src/models/source_models.jl
+++ b/src/models/source_models.jl
@@ -1,4 +1,5 @@
 function mdl_source!(
+    device_parameters,
     voltage_r::T,
     voltage_i::T,
     current_r::AbstractArray{T},
@@ -6,11 +7,9 @@ function mdl_source!(
     static_device::StaticWrapper{PSY.Source},
 ) where {T <: ACCEPTED_REAL_TYPES}
     #Load device parameters
-    V_R = get_V_ref(static_device) * cos(get_θ_ref(static_device))
-    V_I = get_V_ref(static_device) * sin(get_θ_ref(static_device))
-    # TODO: field forwarding
-    R_th = PSY.get_R_th(static_device.device)
-    X_th = PSY.get_X_th(static_device.device)
+    R_th, X_th, internal_voltage, internal_angle = device_parameters
+    V_R = internal_voltage * cos(internal_angle)
+    V_I = internal_voltage * sin(internal_angle)
     Zmag = R_th^2 + X_th^2
 
     #update current

--- a/src/utils/parameters.jl
+++ b/src/utils/parameters.jl
@@ -1,0 +1,967 @@
+
+get_params(
+    d::DynamicWrapper{T},
+) where {T <: Union{PSY.DynamicGenerator, PSY.DynamicInverter}} =
+    vcat(get_params(get_static_device(d)), get_params(get_dynamic_device(d)))
+get_params(d::DynamicWrapper) = get_params(get_dynamic_device(d))
+get_params(d::StaticWrapper) = get_params(get_device(d))
+get_n_params(x::BranchWrapper) = get_n_params(get_branch(x))
+get_params(x::BranchWrapper) = get_params(PSY.get_branch(get_branch(x)))
+get_n_params(x::PSY.DynamicBranch) = get_n_params(PSY.get_branch(x))
+get_n_params(x::PSY.Line) = 2
+get_params(x::PSY.Line) = [PSY.get_r(x), PSY.get_x(x)]
+
+function get_params(d::StaticLoadWrapper)
+    loads = get_loads(d)
+    bus = PSY.get_bus(d)
+    V_ref = PSY.get_magnitude(bus)
+    Θ_ref = PSY.get_angle(bus)
+    sys_base_power = get_system_base_power(d)
+    P_power = 0.0
+    P_current = 0.0
+    P_impedance = 0.0
+    Q_power = 0.0
+    Q_current = 0.0
+    Q_impedance = 0.0
+    for ld in loads
+        base_power_conversion = PSY.get_base_power(ld) / sys_base_power
+        if isa(ld, PSY.PowerLoad)
+            P_power += PSY.get_active_power(ld) * base_power_conversion
+            Q_power += PSY.get_reactive_power(ld) * base_power_conversion
+        elseif isa(ld, PSY.StandardLoad)
+            P_impedance += PSY.get_impedance_active_power(ld) * base_power_conversion
+            Q_impedance += PSY.get_impedance_reactive_power(ld) * base_power_conversion
+            P_current += PSY.get_current_active_power(ld) * base_power_conversion
+            Q_current += PSY.get_current_reactive_power(ld) * base_power_conversion
+            P_power += PSY.get_constant_active_power(ld) * base_power_conversion
+            Q_power += PSY.get_constant_reactive_power(ld) * base_power_conversion
+        end
+    end
+
+    return [V_ref, Θ_ref, P_power, P_current, P_impedance, Q_power, Q_current, Q_impedance]
+end
+
+# TODO - temporary for Dynamic components that have not yet been modified to use parameters.
+# Allows the 
+get_n_params(x::PSY.DynamicComponent) = 0
+get_params(::PSY.DynamicComponent) = Float64[]
+get_params_symbol(::PSY.DynamicComponent) = Symbol[]
+get_n_params(x::PSY.ActivePowerControl) = 0
+get_params(::PSY.ActivePowerControl) = Float64[]
+get_params_symbol(::PSY.ActivePowerControl) = Symbol[]
+get_n_params(x::PSY.ReactivePowerControl) = 0
+get_params(::PSY.ReactivePowerControl) = Float64[]
+get_params_symbol(::PSY.ReactivePowerControl) = Symbol[]
+
+get_n_params(g::PSY.DynamicInverter) =
+    3 + get_n_params(PSY.get_converter(g)) +
+    get_n_params(PSY.get_outer_control(g)) + get_n_params(PSY.get_inner_control(g)) +
+    get_n_params(PSY.get_dc_source(g)) + get_n_params(PSY.get_freq_estimator(g)) +
+    get_n_params(PSY.get_filter(g))
+
+#INVERTERS 
+function get_params(g::PSY.DynamicInverter)
+    refs = [
+        PSY.get_V_ref(g),
+        PSY.get_ω_ref(g),
+        PSY.get_P_ref(g),
+    ]
+    vcat(
+        refs,
+        get_params(PSY.get_converter(g)),
+        get_params(PSY.get_outer_control(g)),
+        get_params(PSY.get_inner_control(g)),
+        get_params(PSY.get_dc_source(g)),
+        get_params(PSY.get_freq_estimator(g)),
+        get_params(PSY.get_filter(g)),
+    )
+end
+get_params_symbol(g::PSY.DynamicInverter) = vcat(
+    [:V_ref, :ω_ref, :P_ref],
+    get_params_symbol(PSY.get_converter(g)),
+    get_params_symbol(PSY.get_outer_control(g)),
+    get_params_symbol(PSY.get_inner_control(g)),
+    get_params_symbol(PSY.get_dc_source(g)),
+    get_params_symbol(PSY.get_freq_estimator(g)),
+    get_params_symbol(PSY.get_filter(g)),
+)
+
+#FILTERS 
+get_n_params(x::PSY.LCLFilter) = 5
+get_params(x::PSY.LCLFilter) =
+    [PSY.get_lf(x), PSY.get_rf(x), PSY.get_cf(x), PSY.get_lg(x), PSY.get_rg(x)]
+get_params_symbol(::PSY.LCLFilter) = [:lf, :rf, :cf, :lg, :rg]
+
+get_n_params(x::PSY.RLFilter) = 2
+get_params(x::PSY.RLFilter) = [PSY.get_rf(x), PSY.get_lf(x)]
+get_params_symbol(::PSY.RLFilter) = [:rf, :lf]
+#OUTER CONTROL
+get_n_params(x::PSY.OuterControl) =
+    get_n_params(PSY.get_active_power_control(x)) +
+    get_n_params(PSY.get_reactive_power_control(x))
+get_params(x::PSY.OuterControl) = vcat(
+    get_params(PSY.get_active_power_control(x)),
+    get_params(PSY.get_reactive_power_control(x)),
+)
+get_params_symbol(x::PSY.OuterControl) = vcat(
+    get_params_symbol(PSY.get_active_power_control(x)),
+    get_params_symbol(PSY.get_reactive_power_control(x)),
+)
+#ACTIVE POWER CONTROL
+get_n_params(::PSY.VirtualInertia) = 3
+get_params(x::PSY.VirtualInertia) = [PSY.get_Ta(x), PSY.get_kd(x), PSY.get_kω(x)]
+get_params_symbol(::PSY.VirtualInertia) = [:Ta, :kd, :kω]
+
+get_n_params(::PSY.ActiveRenewableControllerAB) = 17
+get_params(x::PSY.ActiveRenewableControllerAB) =
+    [PSY.get_K_pg(x),
+        PSY.get_K_ig(x),
+        PSY.get_T_p(x),
+        PSY.get_fdbd_pnts(x)[1],
+        PSY.get_fdbd_pnts(x)[2],
+        PSY.get_fe_lim(x)[1],
+        PSY.get_fe_lim(x)[2],
+        PSY.get_P_lim(x)[1],
+        PSY.get_P_lim(x)[2],
+        PSY.get_T_g(x),
+        PSY.get_D_dn(x),
+        PSY.get_D_up(x),
+        PSY.get_dP_lim(x)[1],
+        PSY.get_dP_lim(x)[2],
+        PSY.get_P_lim_inner(x)[1],
+        PSY.get_P_lim_inner(x)[2],
+        PSY.get_T_pord(x)]
+get_params_symbol(::PSY.ActiveRenewableControllerAB) = [:K_pg,
+    :K_ig,
+    :T_p_ap, #modified to make unique
+    :fdbd1,
+    :fdbd2,
+    :fe_min,
+    :fe_max,
+    :P_min,
+    :P_max,
+    :T_g_ap, #modified to make unique
+    :D_dn,
+    :D_up,
+    :dP_min,
+    :dP_max,
+    :P_min_inner,
+    :P_max_inner,
+    :T_pord]
+
+get_n_params(::PSY.ReactiveRenewableControllerAB) = 22
+get_params(x::PSY.ReactiveRenewableControllerAB) = [PSY.get_T_fltr(x),
+    PSY.get_K_p(x),
+    PSY.get_K_i(x),
+    PSY.get_T_ft(x),
+    PSY.get_T_fv(x),
+    PSY.get_V_frz(x),
+    PSY.get_R_c(x),
+    PSY.get_X_c(x),
+    PSY.get_K_c(x),
+    PSY.get_e_lim(x)[1],
+    PSY.get_e_lim(x)[2],
+    PSY.get_dbd_pnts(x)[1],
+    PSY.get_dbd_pnts(x)[2],
+    PSY.get_Q_lim(x)[1],
+    PSY.get_Q_lim(x)[2],
+    PSY.get_T_p(x),
+    PSY.get_Q_lim_inner(x)[1],
+    PSY.get_Q_lim_inner(x)[2],
+    PSY.get_V_lim(x)[1],
+    PSY.get_V_lim(x)[2],
+    PSY.get_K_qp(x),
+    PSY.get_K_qi(x)]
+get_params_symbol(::PSY.ReactiveRenewableControllerAB) = [:T_fltr,
+    :K_p,
+    :K_i,
+    :T_ft,
+    :T_fv,
+    :V_frz,
+    :R_c,
+    :X_c,
+    :K_c,
+    :e_min,
+    :e_max,
+    :dbd_pnts1,
+    :dbd_pnts2,
+    :Q_min,
+    :Q_max,
+    :T_p,
+    :Q_min_inner,
+    :Q_max_inner,
+    :V_min,
+    :V_max,
+    :K_qp,
+    :K_qi]
+
+#REACTIVE POWER CONTROL
+get_n_params(::PSY.ReactivePowerDroop) = 2
+get_params(x::PSY.ReactivePowerDroop) = [PSY.get_kq(x), PSY.get_ωf(x)]
+get_params_symbol(x::PSY.ReactivePowerDroop) = [:kq, :ωf]
+#INNER CONTROL
+get_n_params(::PSY.VoltageModeControl) = 10
+get_params(x::PSY.VoltageModeControl) =
+    [PSY.get_kpv(x), PSY.get_kiv(x), PSY.get_kffv(x), PSY.get_rv(x), PSY.get_lv(x),
+        PSY.get_kpc(x), PSY.get_kic(x), PSY.get_kffi(x), PSY.get_ωad(x), PSY.get_kad(x)]
+get_params_symbol(x::PSY.VoltageModeControl) =
+    [:kpv, :kiv, :kffv, :rv, :lv, :kpc, :kic, :kffi, :ωad, :kad]
+
+get_n_params(::PSY.RECurrentControlB) = 13
+get_params(x::PSY.RECurrentControlB) =
+    [
+        PSY.get_Vdip_lim(x)[1],
+        PSY.get_Vdip_lim(x)[2],
+        PSY.get_T_rv(x),
+        PSY.get_dbd_pnts(x)[1],
+        PSY.get_dbd_pnts(x)[2],
+        PSY.get_K_qv(x),
+        PSY.get_Iqinj_lim(x)[1],
+        PSY.get_Iqinj_lim(x)[2],
+        PSY.get_V_ref0(x),
+        PSY.get_K_vp(x),
+        PSY.get_K_vi(x),
+        PSY.get_T_iq(x),
+        PSY.get_I_max(x)]
+get_params_symbol(x::PSY.RECurrentControlB) =
+    [:Vdip_min,
+        :Vdip_max,
+        :T_rv,
+        :dbd_pnts_1,
+        :dbd_pnts_2,
+        :K_qv,
+        :Iqinj_min,
+        :Iqinj_max,
+        :V_ref0,
+        :K_vp,
+        :K_vi,
+        :T_iq,
+        :I_max]
+
+#DC SOURCE 
+get_n_params(::PSY.FixedDCSource) = 1
+get_params(x::PSY.FixedDCSource) = [PSY.get_voltage(x)]
+get_params_symbol(x::PSY.FixedDCSource) = [:voltage]
+#FREQ ESTIMATOR
+get_n_params(::PSY.KauraPLL) = 3
+get_params(x::PSY.KauraPLL) = [PSY.get_ω_lp(x), PSY.get_kp_pll(x), PSY.get_ki_pll(x)]
+get_params_symbol(::PSY.KauraPLL) = [:ω_lp, :kp_pll, :ki_pll]
+get_n_params(::PSY.FixedFrequency) = 1
+get_params(x::PSY.FixedFrequency) = [PSY.get_frequency(x)]
+get_params_symbol(::PSY.FixedFrequency) = [:frequency]
+#CONVERTER 
+get_n_params(::PSY.AverageConverter) = 0
+get_params(x::PSY.AverageConverter) = Float64[]
+get_params_symbol(::PSY.AverageConverter) = Symbol[]
+get_n_params(x::PSY.RenewableEnergyConverterTypeA) = 17
+get_params(x::PSY.RenewableEnergyConverterTypeA) = [PSY.get_T_g(x),
+    PSY.get_Rrpwr(x),
+    PSY.get_Brkpt(x),
+    PSY.get_Zerox(x),
+    PSY.get_Lvpl1(x),
+    PSY.get_Vo_lim(x),
+    PSY.get_Lv_pnts(x)[1],
+    PSY.get_Lv_pnts(x)[2],
+    PSY.get_Io_lim(x),
+    PSY.get_T_fltr(x),
+    PSY.get_K_hv(x),
+    PSY.get_Iqr_lims(x)[1],
+    PSY.get_Iqr_lims(x)[2],
+    PSY.get_Accel(x),
+    PSY.get_Q_ref(x),
+    PSY.get_R_source(x),
+    PSY.get_X_source(x)]
+get_params_symbol(::PSY.RenewableEnergyConverterTypeA) = [:T_g,
+    :Rrpwr,
+    :Brkpt,
+    :Zerox,
+    :Lvpl1,
+    :Vo_lim,
+    :Lv_pnt0,
+    :Lv_pnt1,
+    :Io_lim,
+    :T_fltr_cnv,  #modified to make unique
+    :K_hv,
+    :Iqr_min,
+    :Iqr_max,
+    :Accel,
+    :Q_ref_cnv,     #modified to make unique
+    :R_source,
+    :X_source]
+
+#GENERATORS
+get_n_params(g::PSY.DynamicGenerator) =
+    3 +
+    get_n_params(PSY.get_machine(g)) + get_n_params(PSY.get_shaft(g)) +
+    get_n_params(PSY.get_avr(g)) + get_n_params(PSY.get_prime_mover(g)) +
+    get_n_params(PSY.get_pss(g))
+function get_params(g::PSY.DynamicGenerator)
+    refs = [
+        PSY.get_V_ref(g),
+        PSY.get_ω_ref(g),
+        PSY.get_P_ref(g),
+    ]
+    vcat(
+        refs,
+        get_params(PSY.get_machine(g)),
+        get_params(PSY.get_shaft(g)),
+        get_params(PSY.get_avr(g)),
+        get_params(PSY.get_prime_mover(g)),
+        get_params(PSY.get_pss(g)),
+    )
+end
+get_params_symbol(g::PSY.DynamicGenerator) = vcat(
+    [:V_ref, :ω_ref, :P_ref],
+    get_params_symbol(PSY.get_machine(g)),
+    get_params_symbol(PSY.get_shaft(g)),
+    get_params_symbol(PSY.get_avr(g)),
+    get_params_symbol(PSY.get_prime_mover(g)),
+    get_params_symbol(PSY.get_pss(g)),
+)
+
+#MACHINES 
+get_n_params(::PSY.BaseMachine) = 3
+get_params(x::PSY.BaseMachine) = [PSY.get_R(x), PSY.get_Xd_p(x), PSY.get_eq_p(x)]
+get_params_symbol(::PSY.BaseMachine) = [:R, :Xd_p, :eq_p]
+get_n_params(::PSY.OneDOneQMachine) = 7
+get_params(x::PSY.OneDOneQMachine) = [
+    PSY.get_R(x),
+    PSY.get_Xd(x),
+    PSY.get_Xq(x),
+    PSY.get_Xd_p(x),
+    PSY.get_Xq_p(x),
+    PSY.get_Td0_p(x),
+    PSY.get_Tq0_p(x),
+]
+get_params_symbol(x::PSY.OneDOneQMachine) = [:R, :Xd, :Xq, :Xd_p, :Xq_p, :Td0_p, :Tq0_p]
+get_n_params(::PSY.MarconatoMachine) = 14
+get_params(x::PSY.MarconatoMachine) =
+    [PSY.get_R(x), PSY.get_Xd(x), PSY.get_Xq(x), PSY.get_Xd_p(x), PSY.get_Xq_p(x),
+        PSY.get_Xd_pp(x), PSY.get_Xq_pp(x),
+        PSY.get_Td0_p(x), PSY.get_Tq0_p(x), PSY.get_Td0_pp(x), PSY.get_Tq0_pp(x),
+        PSY.get_T_AA(x), PSY.get_γd(x), PSY.get_γq(x)]
+get_params_symbol(x::PSY.MarconatoMachine) = [
+    :R,
+    :Xd,
+    :Xq,
+    :Xd_p,
+    :Xq_p,
+    :Xd_pp,
+    :Xq_pp,
+    :Td0_p,
+    :Tq0_p,
+    :Td0_pp,
+    :Tq0_pp,
+    :T_AA,
+    :γd,
+    :γq,
+]
+get_n_params(::PSY.AndersonFouadMachine) = 11
+get_params(x::PSY.AndersonFouadMachine) = [
+    PSY.get_R(x),
+    PSY.get_Xd(x),
+    PSY.get_Xq(x),
+    PSY.get_Xd_p(x),
+    PSY.get_Xq_p(x),
+    PSY.get_Xd_pp(x),
+    PSY.get_Xq_pp(x),
+    PSY.get_Td0_p(x),
+    PSY.get_Tq0_p(x),
+    PSY.get_Td0_pp(x),
+    PSY.get_Tq0_pp(x)]
+
+get_params_symbol(x::PSY.AndersonFouadMachine) = [:R,
+    :Xd,
+    :Xq,
+    :Xd_p,
+    :Xq_p,
+    :Xd_pp,
+    :Xq_pp,
+    :Td0_p,
+    :Tq0_p,
+    :Td0_pp,
+    :Tq0_pp]
+
+#NOTE: Saturation not considered as paramters
+get_n_params(
+    x::Union{PSY.RoundRotorMachine, PSY.RoundRotorExponential, PSY.RoundRotorQuadratic},
+) = 16
+get_params(
+    x::Union{PSY.RoundRotorMachine, PSY.RoundRotorExponential, PSY.RoundRotorQuadratic},
+) = [
+    PSY.get_R(x),
+    PSY.get_Td0_p(x),
+    PSY.get_Td0_pp(x),
+    PSY.get_Tq0_p(x),
+    PSY.get_Tq0_pp(x),
+    PSY.get_Xd(x),
+    PSY.get_Xq(x),
+    PSY.get_Xd_p(x),
+    PSY.get_Xq_p(x),
+    PSY.get_Xd_pp(x),
+    PSY.get_Xl(x),
+    PSY.get_γ_d1(x),
+    PSY.get_γ_q1(x),
+    PSY.get_γ_d2(x),
+    PSY.get_γ_q2(x),
+    PSY.get_γ_qd(x),
+]
+get_params_symbol(
+    ::Union{PSY.RoundRotorMachine, PSY.RoundRotorExponential, PSY.RoundRotorQuadratic},
+) = [
+    :R,
+    :Td0_p,
+    :Td0_pp,
+    :Tq0_p,
+    :Tq0_pp,
+    :Xd,
+    :Xq,
+    :Xd_p,
+    :Xq_p,
+    :Xd_pp,
+    :Xl,
+    :γ_d1,
+    :γ_q1,
+    :γ_d2,
+    :γ_q2,
+    :γ_qd,
+]
+get_n_params(
+    ::Union{PSY.SalientPoleMachine, PSY.SalientPoleExponential, PSY.SalientPoleQuadratic},
+) = 12
+get_params(
+    x::Union{PSY.SalientPoleMachine, PSY.SalientPoleExponential, PSY.SalientPoleQuadratic},
+) = [
+    PSY.get_R(x),
+    PSY.get_Td0_p(x),
+    PSY.get_Td0_pp(x),
+    PSY.get_Tq0_pp(x),
+    PSY.get_Xd(x),
+    PSY.get_Xq(x),
+    PSY.get_Xd_p(x),
+    PSY.get_Xd_pp(x),
+    PSY.get_Xl(x),
+    PSY.get_γ_d1(x),
+    PSY.get_γ_q1(x),
+    PSY.get_γ_d2(x),
+]
+get_params_symbol(
+    ::Union{PSY.SalientPoleMachine, PSY.SalientPoleExponential, PSY.SalientPoleQuadratic},
+) = [
+    :R,
+    :Td0_p,
+    :Td0_pp,
+    :Tq0_pp,
+    :Xd,
+    :Xq,
+    :Xd_p,
+    :Xd_pp,
+    :Xl,
+    :γ_d1,
+    :γ_q1,
+    :γ_d2,
+]
+
+#SHAFTS
+get_n_params(::PSY.SingleMass) = 2
+get_params(x::PSY.SingleMass) = [PSY.get_H(x), PSY.get_D(x)]
+get_params_symbol(::PSY.SingleMass) = [:H, :D]
+get_n_params(::PSY.FiveMassShaft) = 18
+get_params(x::PSY.FiveMassShaft) = [
+    PSY.get_H(x),
+    PSY.get_H_hp(x),
+    PSY.get_H_ip(x),
+    PSY.get_H_lp(x),
+    PSY.get_H_ex(x),
+    PSY.get_D(x),
+    PSY.get_D_hp(x),
+    PSY.get_D_ip(x),
+    PSY.get_D_lp(x),
+    PSY.get_D_ex(x),
+    PSY.get_D_12(x),
+    PSY.get_D_23(x),
+    PSY.get_D_34(x),
+    PSY.get_D_45(x),
+    PSY.get_K_hp(x),
+    PSY.get_K_ip(x),
+    PSY.get_K_lp(x),
+    PSY.get_K_ex(x),
+]
+
+get_params_symbol(::PSY.FiveMassShaft) = [
+    :H,
+    :H_hp,
+    :H_ip,
+    :H_lp,
+    :H_ex,
+    :D,
+    :D_hp,
+    :D_ip,
+    :D_lp,
+    :D_ex,
+    :D_12,
+    :D_23,
+    :D_34,
+    :D_45,
+    :K_hp,
+    :K_ip,
+    :K_lp,
+    :K_ex]
+
+#AVRS 
+get_n_params(::PSY.AVRFixed) = 0
+get_params(x::PSY.AVRFixed) = Float64[]
+get_params_symbol(::PSY.AVRFixed) = Symbol[]
+get_n_params(::PSY.AVRSimple) = 1
+get_params(x::PSY.AVRSimple) = [PSY.get_Kv(x)]
+get_params_symbol(::PSY.AVRSimple) = [:Kv]
+get_n_params(::PSY.AVRTypeI) = 9
+get_params(x::PSY.AVRTypeI) = [
+    PSY.get_Ka(x),
+    PSY.get_Ke(x),
+    PSY.get_Kf(x),
+    PSY.get_Ta(x),
+    PSY.get_Te(x),
+    PSY.get_Tf(x),
+    PSY.get_Tr(x),
+    PSY.get_Ae(x),
+    PSY.get_Be(x),
+]
+get_params_symbol(::PSY.AVRTypeI) = [:Ka, :Ke, :Kf, :Ta, :Te, :Tf, :Tr, :Ae, :Be]
+get_n_params(::PSY.SEXS) = 6
+get_params(x::PSY.SEXS) = [
+    PSY.get_Ta_Tb(x),
+    PSY.get_Tb(x),
+    PSY.get_K(x),
+    PSY.get_Te(x),
+    PSY.get_V_lim(x)[1],
+    PSY.get_V_lim(x)[2],
+]
+get_params_symbol(::PSY.SEXS) = Symbol[:Ta_Tb, :Tb, :K, :Te, :V_min_avr, :V_max_avr]
+get_n_params(::PSY.AVRTypeII) = 11
+get_params(x::PSY.AVRTypeII) =
+    [PSY.get_K0(x),
+        PSY.get_T1(x),
+        PSY.get_T2(x),
+        PSY.get_T3(x),
+        PSY.get_T4(x),
+        PSY.get_Te(x),
+        PSY.get_Tr(x),
+        PSY.get_Va_lim(x)[1],
+        PSY.get_Va_lim(x)[2],
+        PSY.get_Ae(x),
+        PSY.get_Be(x)]
+get_params_symbol(::PSY.AVRTypeII) =
+    [:K0,
+        :T1,
+        :T2,
+        :T3,
+        :T4,
+        :Te,
+        :Tr,
+        :Va_min,
+        :Va_max,
+        :Ae,
+        :Be]
+get_n_params(::PSY.ESAC1A) = 15
+get_params(x::PSY.ESAC1A) = [
+    PSY.get_Tr(x),
+    PSY.get_Tb(x),
+    PSY.get_Tc(x),
+    PSY.get_Ka(x),
+    PSY.get_Ta(x),
+    PSY.get_Va_lim(x)[1],
+    PSY.get_Va_lim(x)[2],
+    PSY.get_Te(x),
+    PSY.get_Kf(x),
+    PSY.get_Tf(x),
+    PSY.get_Kc(x),
+    PSY.get_Kd(x),
+    PSY.get_Ke(x),
+    PSY.get_Vr_lim(x)[1],
+    PSY.get_Vr_lim(x)[2]]
+get_params_symbol(::PSY.ESAC1A) = [:Tr,
+    :Tb,
+    :Tc,
+    :Ka,
+    :Ta,
+    :Va_min,
+    :Va_max,
+    :Te,
+    :Kf,
+    :Tf,
+    :Kc,
+    :Kd,
+    :Ke,
+    :Vr_min,
+    :Vr_max]
+get_n_params(::PSY.EXST1) = 12
+get_params(x::PSY.EXST1) = [PSY.get_Tr(x),
+    PSY.get_Vi_lim(x)[1],
+    PSY.get_Vi_lim(x)[2],
+    PSY.get_Tc(x),
+    PSY.get_Tb(x),
+    PSY.get_Ka(x),
+    PSY.get_Ta(x),
+    PSY.get_Vr_lim(x)[1],
+    PSY.get_Vr_lim(x)[2],
+    PSY.get_Kc(x),
+    PSY.get_Kf(x),
+    PSY.get_Tf(x)]
+get_params_symbol(::PSY.EXST1) = [
+    :Tr_avr, #modified to make unique
+    :Vi_min,
+    :Vi_max,
+    :Tc,
+    :Tb,
+    :Ka,
+    :Ta,
+    :Vr_min,
+    :Vr_max,
+    :Kc,
+    :Kf,
+    :Tf_avr, #modified to make unique
+]
+
+get_n_params(::PSY.EXAC1) = 13
+get_params(x::PSY.EXAC1) = [
+    PSY.get_Tr(x),
+    PSY.get_Tb(x),
+    PSY.get_Tc(x),
+    PSY.get_Ka(x),
+    PSY.get_Ta(x),
+    PSY.get_Vr_lim(x)[1],
+    PSY.get_Vr_lim(x)[2],
+    PSY.get_Te(x),
+    PSY.get_Kf(x),
+    PSY.get_Tf(x),
+    PSY.get_Kc(x),
+    PSY.get_Kd(x),
+    PSY.get_Ke(x)]
+
+get_params_symbol(::PSY.EXAC1) = [
+    :Tr_avr,  #modified to make unique
+    :Tb,
+    :Tc,
+    :Ka,
+    :Ta,
+    :Vr_min,
+    :Vr_max,
+    :Te,
+    :Kf,
+    :Tf_avr,  #modified to make unique
+    :Kc,
+    :Kd,
+    :Ke]
+
+#PRIME MOVERS
+get_n_params(::PSY.TGFixed) = 1
+get_params(x::PSY.TGFixed) = [PSY.get_efficiency(x)]
+get_params_symbol(::PSY.TGFixed) = [:efficiency]
+get_n_params(::PSY.TGTypeII) = 3
+get_params(x::PSY.TGTypeII) = [PSY.get_R(x), PSY.get_T1(x), PSY.get_T2(x)]
+get_params_symbol(::PSY.TGTypeII) = [:R_tg, :T1, :T2]
+get_n_params(::PSY.GasTG) = 9
+get_params(x::PSY.GasTG) = [
+    PSY.get_R(x),
+    PSY.get_T1(x),
+    PSY.get_T2(x),
+    PSY.get_T3(x),
+    PSY.get_AT(x),
+    PSY.get_Kt(x),
+    PSY.get_V_lim(x)[1],
+    PSY.get_V_lim(x)[2],
+    PSY.get_D_turb(x),
+]
+get_params_symbol(::PSY.GasTG) = [:R_tg, :T1, :T2, :T3, :AT, :Kt, :V_min, :V_max, :D_turb]
+get_n_params(::PSY.TGTypeI) = 8
+get_params(x::PSY.TGTypeI) = [PSY.get_R(x),
+    PSY.get_Ts(x),
+    PSY.get_Tc(x),
+    PSY.get_T3(x),
+    PSY.get_T4(x),
+    PSY.get_T5(x),
+    PSY.get_valve_position_limits(x)[1],
+    PSY.get_valve_position_limits(x)[2],
+]
+
+get_params_symbol(::PSY.TGTypeI) = [:R_tg,
+    :Ts,
+    :Tc,
+    :T3_tg, #modified to make unique
+    :T4_tg, #modified to make unique
+    :T5_tg, #modified to make unique
+    :valve_position_min,
+    :valve_position_max,
+]
+get_n_params(::PSY.SteamTurbineGov1) = 7
+get_params(x::PSY.SteamTurbineGov1) = [PSY.get_R(x),
+    PSY.get_T1(x),
+    PSY.get_valve_position_limits(x)[1],
+    PSY.get_valve_position_limits(x)[2],
+    PSY.get_T2(x),
+    PSY.get_T3(x),
+    PSY.get_D_T(x)]
+get_params_symbol(::PSY.SteamTurbineGov1) = [:R_tg,
+    :T1_tg, #modified to make unique
+    :valve_position_min,
+    :valve_position_max,
+    :T2_tg,  #modified to make unique
+    :T3_tg,  #modified to make unique
+    :D_T]
+get_params_symbol(::PSY.TGTypeI) = [:R_tg,
+    :Ts,
+    :Tc,
+    :T3_tg, #modified to make unique
+    :T4_tg, #modified to make unique
+    :T5_tg, #modified to make unique
+    :valve_position_min,
+    :valve_position_max,
+]
+get_n_params(::PSY.HydroTurbineGov) = 12
+get_params(x::PSY.HydroTurbineGov) = [PSY.get_R(x),
+    PSY.get_r(x),
+    PSY.get_Tr(x),
+    PSY.get_Tf(x),
+    PSY.get_Tg(x),
+    PSY.get_VELM(x),
+    PSY.get_gate_position_limits(x)[1],
+    PSY.get_gate_position_limits(x)[2],
+    PSY.get_Tw(x),
+    PSY.get_At(x),
+    PSY.get_D_T(x),
+    PSY.get_q_nl(x)]
+get_params_symbol(::PSY.HydroTurbineGov) = [
+    :R_tg,  #modified to make unique
+    :r,
+    :Tr,
+    :Tf,
+    :Tg,
+    :VELM,
+    :G_min,
+    :G_max,
+    :Tw,
+    :At,
+    :D_T,
+    :q_nl]
+
+#PSS
+get_n_params(::PSY.PSSFixed) = 1
+get_params(x::PSY.PSSFixed) = [PSY.get_V_pss(x)]
+get_params_symbol(::PSY.PSSFixed) = [:V_pss]
+
+get_n_params(::PSY.STAB1) = 7
+get_params(x::PSY.STAB1) = [PSY.get_KT(x),
+    PSY.get_T(x),
+    PSY.get_T1T3(x),
+    PSY.get_T3(x),
+    PSY.get_T2T4(x),
+    PSY.get_T4(x),
+    PSY.get_H_lim(x)]
+get_params_symbol(::PSY.STAB1) =
+    [:KT,
+        :T,
+        :T1T3,
+        :T3,
+        :T2T4,
+        :T4,
+        :H_lim]
+
+#STATIC INJECTION
+get_n_params(::PSY.StaticInjection) = 1
+get_params(x::PSY.StaticInjection) = [PSY.get_reactive_power(x)]
+get_params_symbol(::PSY.StaticInjection) = [:Q_ref]
+
+get_n_params(::PSY.StandardLoad) = 1
+get_params(x::PSY.StandardLoad) = [PF.get_total_q(x)]
+get_params_symbol(::PSY.StandardLoad) = [:Q_ref]
+#SOURCE 
+get_n_params(::PSY.Source) = 4
+get_params(x::PSY.Source) = [
+    PSY.get_R_th(x),
+    PSY.get_X_th(x),
+    PSY.get_internal_voltage(x),
+    PSY.get_internal_angle(x),
+]
+#Parameters not implemented for PVS - requires change in PSY Struct to have information required to construct and deconstruct parameter vector
+get_n_params(x::PSY.PeriodicVariableSource) = 4
+get_params(x::PSY.PeriodicVariableSource) = Float64[0.0, 0.0, 0.0, 0.0]
+
+#DYNAMIC LOADS 
+get_n_params(::PSY.ActiveConstantPowerLoad) = 18
+get_params(x::PSY.ActiveConstantPowerLoad) =
+    [
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        PSY.get_r_load(x),
+        PSY.get_c_dc(x),
+        PSY.get_rf(x),
+        PSY.get_lf(x),
+        PSY.get_cf(x),
+        PSY.get_rg(x),
+        PSY.get_lg(x),
+        PSY.get_kp_pll(x),
+        PSY.get_ki_pll(x),
+        PSY.get_kpv(x),
+        PSY.get_kiv(x),
+        PSY.get_kpc(x),
+        PSY.get_kic(x),
+        PSY.get_base_power(x)]
+get_params_symbol(::PSY.ActiveConstantPowerLoad) =
+    [
+        :Q_ref,
+        :V_ref,
+        :ω_ref,
+        :P_ref,
+        :r_load,
+        :c_dc,
+        :rf,
+        :lf,
+        :cf,
+        :rg,
+        :lg,
+        :kp_pll,
+        :ki_pll,
+        :kpv,
+        :kiv,
+        :kpc,
+        :kic,
+        :base_power]
+
+get_n_params(::PSY.SingleCageInductionMachine) = 18
+get_params(x::PSY.SingleCageInductionMachine) = [
+    0.0,#refs unused
+    0.0,#refs unused
+    0.0, #refs unused
+    0.0,  #refs unused
+    PSY.get_R_s(x),
+    PSY.get_R_r(x),
+    PSY.get_X_ls(x),
+    PSY.get_X_lr(x),
+    PSY.get_X_m(x),
+    PSY.get_H(x),
+    PSY.get_A(x),
+    PSY.get_B(x),
+    PSY.get_base_power(x),
+    PSY.get_C(x),
+    PSY.get_τ_ref(x),
+    PSY.get_B_shunt(x),
+    PSY.get_X_ad(x),
+    PSY.get_X_aq(x)]
+get_params_symbol(::PSY.SingleCageInductionMachine) = [
+    :Q_ref,
+    :V_ref,
+    :ω_ref,
+    :P_ref,
+    :R_s,
+    :R_r,
+    :X_ls,
+    :X_lr,
+    :X_m,
+    :H,
+    :A,
+    :B,
+    :base_power,
+    :C,
+    :τ_ref,
+    :B_shunt,
+    :X_ad,
+    :X_aq]
+get_n_params(::PSY.SimplifiedSingleCageInductionMachine) = 19
+get_params(x::PSY.SimplifiedSingleCageInductionMachine) = [
+    0.0,#refs unused
+    0.0,#refs unused
+    0.0, #refs unused
+    0.0,  #refs unused
+    PSY.get_R_s(x),
+    PSY.get_R_r(x),
+    PSY.get_X_ls(x),
+    PSY.get_X_lr(x),
+    PSY.get_X_m(x),
+    PSY.get_H(x),
+    PSY.get_A(x),
+    PSY.get_B(x),
+    PSY.get_base_power(x),
+    PSY.get_C(x),
+    PSY.get_τ_ref(x),
+    PSY.get_B_shunt(x),
+    PSY.get_X_ss(x),
+    PSY.get_X_rr(x),
+    PSY.get_X_p(x)]
+get_params_symbol(::PSY.SimplifiedSingleCageInductionMachine) = [
+    :Q_ref,
+    :V_ref,
+    :ω_ref,
+    :P_ref,
+    :R_s,
+    :R_r,
+    :X_ls,
+    :X_lr,
+    :X_m,
+    :H,
+    :A,
+    :B,
+    :base_power,
+    :C,
+    :τ_ref,
+    :B_shunt,
+    :X_ss,
+    :X_rr,
+    :X_p]
+
+get_n_params(x::PSY.AggregateDistributedGenerationA) = 33
+get_params(x::PSY.AggregateDistributedGenerationA) = [PSY.get_Q_ref(x),
+    PSY.get_V_ref(x),
+    PSY.get_ω_ref(x),
+    PSY.get_P_ref(x),
+    PSY.get_T_rv(x),
+    PSY.get_Trf(x),
+    PSY.get_dbd_pnts(x)[1],
+    PSY.get_dbd_pnts(x)[2],
+    PSY.get_K_qv(x),
+    PSY.get_Tp(x),
+    PSY.get_T_iq(x),
+    PSY.get_D_dn(x),
+    PSY.get_D_up(x),
+    PSY.get_fdbd_pnts(x)[1],
+    PSY.get_fdbd_pnts(x)[2],
+    PSY.get_fe_lim(x)[1],
+    PSY.get_fe_lim(x)[2],
+    PSY.get_P_lim(x)[1],
+    PSY.get_P_lim(x)[2],
+    PSY.get_dP_lim(x)[1],
+    PSY.get_dP_lim(x)[2],
+    PSY.get_Tpord(x),
+    PSY.get_Kpg(x),
+    PSY.get_Kig(x),
+    PSY.get_I_max(x),
+    PSY.get_Tg(x),
+    PSY.get_rrpwr(x),
+    PSY.get_Tv(x),
+    PSY.get_Vpr(x),
+    PSY.get_Iq_lim(x)[1],
+    PSY.get_Iq_lim(x)[2],
+    PSY.get_base_power(x),
+    PSY.get_Pfa_ref(x)]
+
+get_n_params(x::PSY.CSVGN1) = 17
+get_params(x::PSY.CSVGN1) = [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    PSY.get_K(x),
+    PSY.get_T1(x),
+    PSY.get_T2(x),
+    PSY.get_T3(x),
+    PSY.get_T4(x),
+    PSY.get_T5(x),
+    PSY.get_Rmin(x),
+    PSY.get_Vmax(x),
+    PSY.get_Vmin(x),
+    PSY.get_CBase(x),
+    PSY.get_base_power(x),
+    PSY.get_R_th(x),
+    PSY.get_X_th(x)]

--- a/test/test_base.jl
+++ b/test/test_base.jl
@@ -458,15 +458,15 @@ end
 
     inputs = PSID.SimulationInputs(ResidualModel, threebus_sys, ConstantFrequency())
     integrator_for_test = MockIntegrator(inputs)
-
     cref_affect_f = PSID.get_affect(inputs, threebus_sys, cref)
     ωref_affect_f = PSID.get_affect(inputs, threebus_sys, ωref)
-
     cref_affect_f(integrator_for_test)
     ωref_affect_f(integrator_for_test)
+    p_ix1 = PSID.get_p_range(inputs.dynamic_injectors[1])
+    p_ix2 = PSID.get_p_range(inputs.dynamic_injectors[2])
 
-    @test PSID.get_P_ref(inputs.dynamic_injectors[1]) == 10.0
-    @test PSID.get_ω_ref(inputs.dynamic_injectors[2]) == 0.9
+    @test integrator_for_test.p[p_ix1][PSID.P_ref_ix] == 10.0
+    @test integrator_for_test.p[p_ix2][PSID.ω_ref_ix] == 0.9
 
     inputs = PSID.SimulationInputs(ResidualModel, threebus_sys, ConstantFrequency())
     integrator_for_test = MockIntegrator(inputs)
@@ -516,11 +516,13 @@ end
 
     lref_affect_f(integrator_for_test)
     zip_load1 = first(filter(x -> PSY.get_name(x) == "BUS 1", inputs.static_loads))
-    @test PSID.get_P_impedance(zip_load1) == 10.0
+    p_ix1 = PSID.get_p_range(zip_load1)
+    @test integrator_for_test.p[p_ix1][5] == 10.0
     ltrip_affect_f(integrator_for_test)
     zip_load2 = first(filter(x -> PSY.get_name(x) == "BUS 2", inputs.static_loads))
-    @test PSID.get_P_impedance(zip_load2) == 0.0
-    @test PSID.get_Q_impedance(zip_load2) == 0.0
+    p_ix2 = PSID.get_p_range(zip_load2)
+    @test integrator_for_test.p[p_ix2][5] == 0.0
+    @test integrator_for_test.p[p_ix2][8] == 0.0
 end
 
 @testset "Global Index" begin
@@ -779,6 +781,7 @@ end
         gen,
         case_gen,
         1,
+        1:6,
         1:6,
         1:6,
         1:9,

--- a/test/test_case22_SteamTurbineGov1.jl
+++ b/test/test_case22_SteamTurbineGov1.jl
@@ -12,7 +12,7 @@ raw_file = joinpath(TEST_FILES_DIR, "benchmarks/psse/TGOV1/ThreeBusMulti.raw")
 dyr_file = joinpath(TEST_FILES_DIR, "benchmarks/psse/TGOV1/ThreeBus_TGOV1.dyr")
 csv_file = joinpath(TEST_FILES_DIR, "benchmarks/psse/TGOV1/TEST_TGOV1.csv")
 
-@testset "Test 21 SteamTurbineGov1 ResidualModel" begin
+@testset "Test 22 SteamTurbineGov1 ResidualModel" begin
     path = mktempdir()
     try
         sys = System(raw_file, dyr_file)
@@ -72,7 +72,7 @@ csv_file = joinpath(TEST_FILES_DIR, "benchmarks/psse/TGOV1/TEST_TGOV1.csv")
     end
 end
 
-@testset "Test 21 SteamTurbineGov1 MassMatrixModel" begin
+@testset "Test 22 SteamTurbineGov1 MassMatrixModel" begin
     path = (joinpath(pwd(), "test-psse-tgov1"))
     !isdir(path) && mkdir(path)
     try

--- a/test/utils/mock_structs.jl
+++ b/test/utils/mock_structs.jl
@@ -8,6 +8,6 @@ function MockIntegrator(inputs)
     return MockIntegrator(
         zeros(PSID.get_variable_count(inputs)),
         zeros(PSID.get_variable_count(inputs)),
-        inputs,
+        PSID.get_parameters(inputs),
     )
 end


### PR DESCRIPTION
My goal is to make the building of a simulation and the solution differentiable. This will enable sensitivity analysis of the output of a dynamic simulation wrt some parameters of the system model. The first commit addresses the first step which is to build out the capability of passing and handling parameters as a flat vector (similar to the states).

- [x] Pass parameters as a flat vector when constructing the differential equation problem.
- [ ] Simulation flow upgrades
- [ ] Changes for compatibility with automatic differentiation (Zygote)
- [ ] Sensitivity analysis API