### PR TITLE
add unique_timestamps option for post processing

### DIFF
--- a/src/base/simulation_results.jl
+++ b/src/base/simulation_results.jl
@@ -36,20 +36,24 @@ Internal function to obtain as a Vector of Float64 of a specific state. It recei
 global index for a state.
 
 """
-function _post_proc_state_series(solution, ix::Int, dt::Nothing)
-    ix_t = unique(i -> solution.t[i], eachindex(solution.t))
+function _post_proc_state_series(solution, ix::Int, dt::Nothing, unique_timestamps::Bool)
+    if unique_timestamps
+        ix_t = unique(i -> solution.t[i], eachindex(solution.t))
+    else
+        ix_t = eachindex(solution.t)
+    end
     ts = solution.t[ix_t]
     state = solution[ix, ix_t]
     return ts, state
 end
 
-function _post_proc_state_series(solution, ix::Int, dt::Float64)
+function _post_proc_state_series(solution, ix::Int, dt::Float64, ::Bool)
     ts = collect(range(0; stop = solution.t[end], step = dt))
     state = solution(ts; idxs = ix)
     return ts, state.u
 end
 
-function _post_proc_state_series(solution, ix::Int, dt::Vector{Float64})
+function _post_proc_state_series(solution, ix::Int, dt::Vector{Float64}, ::Bool)
     state = solution(dt; idxs = ix)
     return dt, state.u
 end
@@ -62,6 +66,7 @@ function post_proc_state_series(
     res::SimulationResults,
     ref::Tuple{String, Symbol},
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
     global_state_index = get_global_index(res)
     if !haskey(global_state_index, ref[1])
@@ -69,7 +74,7 @@ function post_proc_state_series(
         error("State $(ref[2]) device $(ref[1]) not found in the system. ")
     end
     ix = get(global_state_index[ref[1]], ref[2], 0)
-    return _post_proc_state_series(get_solution(res), ix, dt)
+    return _post_proc_state_series(get_solution(res), ix, dt, unique_timestamps)
 end
 
 """
@@ -80,6 +85,7 @@ function post_proc_voltage_current_series(
     res::SimulationResults,
     name::String,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )::NTuple{5, Vector{Float64}}
     #Note: Type annotation since get_dynamic_injector is type unstable and solution is Union{Nothing, DAESol}
     system = get_system(res)
@@ -91,12 +97,14 @@ function post_proc_voltage_current_series(
         error("Device $(name) not found in the system")
     end
     bus_ix = get(bus_lookup, PSY.get_number(PSY.get_bus(device)), -1)
-    ts, V_R, V_I = post_proc_voltage_series(solution, bus_ix, n_buses, dt)
+    ts, V_R, V_I =
+        post_proc_voltage_series(solution, bus_ix, n_buses, dt, unique_timestamps)
     dyn_device = PSY.get_dynamic_injector(device)
     if isnothing(dyn_device)
-        _, I_R, I_I = compute_output_current(res, device, V_R, V_I, dt)
+        _, I_R, I_I = compute_output_current(res, device, V_R, V_I, dt, unique_timestamps)
     else
-        _, I_R, I_I = compute_output_current(res, dyn_device, V_R, V_I, dt)
+        _, I_R, I_I =
+            compute_output_current(res, dyn_device, V_R, V_I, dt, unique_timestamps)
     end
     return ts, V_R, V_I, I_R, I_I
 end
@@ -111,10 +119,11 @@ function post_proc_voltage_series(
     bus_ix::Int,
     n_buses::Int,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
     bus_ix < 0 && error("Bus number $(bus_number) not found.")
-    ts, V_R = _post_proc_state_series(solution, bus_ix, dt)
-    _, V_I = _post_proc_state_series(solution, bus_ix + n_buses, dt)
+    ts, V_R = _post_proc_state_series(solution, bus_ix, dt, unique_timestamps)
+    _, V_I = _post_proc_state_series(solution, bus_ix + n_buses, dt, unique_timestamps)
     return collect(ts), collect(V_R), collect(V_I)
 end
 
@@ -127,8 +136,9 @@ function post_proc_real_current_series(
     res::SimulationResults,
     name::String,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
-    ts, _, _, I_R, _ = post_proc_voltage_current_series(res, name, dt)
+    ts, _, _, I_R, _ = post_proc_voltage_current_series(res, name, dt, unique_timestamps)
     return ts, I_R
 end
 """
@@ -140,8 +150,9 @@ function post_proc_imaginary_current_series(
     res::SimulationResults,
     name::String,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
-    ts, _, _, _, I_I = post_proc_voltage_current_series(res, name, dt)
+    ts, _, _, _, I_I = post_proc_voltage_current_series(res, name, dt, unique_timestamps)
     return ts, I_I
 end
 
@@ -154,8 +165,10 @@ function post_proc_activepower_series(
     res::SimulationResults,
     name::String,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
-    ts, V_R, V_I, I_R, I_I = post_proc_voltage_current_series(res, name, dt)
+    ts, V_R, V_I, I_R, I_I =
+        post_proc_voltage_current_series(res, name, dt, unique_timestamps)
     return ts, V_R .* I_R + V_I .* I_I
 end
 
@@ -168,8 +181,10 @@ function post_proc_reactivepower_series(
     res::SimulationResults,
     name::String,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
-    ts, V_R, V_I, I_R, I_I = post_proc_voltage_current_series(res, name, dt)
+    ts, V_R, V_I, I_R, I_I =
+        post_proc_voltage_current_series(res, name, dt, unique_timestamps)
     return ts, V_I .* I_R - V_R .* I_I
 end
 
@@ -182,6 +197,7 @@ function post_proc_field_current_series(
     res::SimulationResults,
     name::String,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
     system = get_system(res)
     bus_lookup = get_bus_lookup(res)
@@ -189,9 +205,10 @@ function post_proc_field_current_series(
     solution = res.solution
     device = PSY.get_component(PSY.StaticInjection, system, name)
     bus_ix = get(bus_lookup, PSY.get_number(PSY.get_bus(device)), -1)
-    ts, V_R, V_I = post_proc_voltage_series(solution, bus_ix, n_buses, dt)
+    ts, V_R, V_I =
+        post_proc_voltage_series(solution, bus_ix, n_buses, dt, unique_timestamps)
     dyn_device = PSY.get_dynamic_injector(device)
-    _, I_fd = compute_field_current(res, dyn_device, V_R, V_I, dt)
+    _, I_fd = compute_field_current(res, dyn_device, V_R, V_I, dt, unique_timestamps)
     return ts, I_fd
 end
 
@@ -204,11 +221,12 @@ function post_proc_field_voltage_series(
     res::SimulationResults,
     name::String,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
     system = get_system(res)
     device = PSY.get_component(PSY.StaticInjection, system, name)
     dyn_device = PSY.get_dynamic_injector(device)
-    ts, Vf = compute_field_voltage(res, dyn_device, dt)
+    ts, Vf = compute_field_voltage(res, dyn_device, dt, unique_timestamps)
     return ts, Vf
 end
 
@@ -221,11 +239,12 @@ function post_proc_pss_output_series(
     res::SimulationResults,
     name::String,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
     system = get_system(res)
     device = PSY.get_component(PSY.StaticInjection, system, name)
     dyn_device = PSY.get_dynamic_injector(device)
-    ts, Vs = compute_pss_output(res, dyn_device, dt)
+    ts, Vs = compute_pss_output(res, dyn_device, dt, unique_timestamps)
     return ts, Vs
 end
 
@@ -238,11 +257,12 @@ function post_proc_mechanical_torque_series(
     res::SimulationResults,
     name::String,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
     system = get_system(res)
     device = PSY.get_component(PSY.StaticInjection, system, name)
     dyn_device = PSY.get_dynamic_injector(device)
-    ts, τm = compute_mechanical_torque(res, dyn_device, dt)
+    ts, τm = compute_mechanical_torque(res, dyn_device, dt, unique_timestamps)
     return ts, τm
 end
 
@@ -254,6 +274,7 @@ function post_proc_branch_series(
     res::SimulationResults,
     name::String,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
     system = get_system(res)
     bus_lookup = get_bus_lookup(res)
@@ -267,8 +288,10 @@ function post_proc_branch_series(
     bus_to_number = PSY.get_number(PSY.get_to(PSY.get_arc(branch)))
     bus_from_ix = get(bus_lookup, bus_from_number, -1)
     bus_to_ix = get(bus_lookup, bus_to_number, -1)
-    ts, V_R_from, V_I_from = post_proc_voltage_series(solution, bus_from_ix, n_buses, dt)
-    _, V_R_to, V_I_to = post_proc_voltage_series(solution, bus_to_ix, n_buses, dt)
+    ts, V_R_from, V_I_from =
+        post_proc_voltage_series(solution, bus_from_ix, n_buses, dt, unique_timestamps)
+    _, V_R_to, V_I_to =
+        post_proc_voltage_series(solution, bus_to_ix, n_buses, dt, unique_timestamps)
     r = PSY.get_r(branch)
     x = PSY.get_x(branch)
     I_flow = ((V_R_from + V_I_from * 1im) - (V_R_to + V_I_to * 1im)) ./ (r + x * 1im)
@@ -282,6 +305,7 @@ function post_proc_frequency_series(
     res::SimulationResults,
     name::String,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
     system = get_system(res)
     device = PSY.get_component(PSY.StaticInjection, system, name)
@@ -289,14 +313,15 @@ function post_proc_frequency_series(
     if isnothing(dyn_device)
         error("Dynamic Injection $(name) not found in the system")
     end
-    ts, ω = compute_frequency(res, dyn_device, dt)
+    ts, ω = compute_frequency(res, dyn_device, dt, unique_timestamps)
 end
 
 """
     get_state_series(
         res::SimulationResults,
         ref::Tuple{String, Symbol};
-        dt::Union{Nothing, Float64, Vector{Float64}} = nothing
+        dt::Union{Nothing, Float64, Vector{Float64}} = nothing,
+        unique_timestamps::Bool = true,
     )
     end
 
@@ -307,8 +332,13 @@ Function to obtain series of states out of DAE Solution.
 - `res::SimulationResults` : Simulation Results object that contains the solution
 - `ref:Tuple{String, Symbol}` : Tuple used to identify the dynamic device, via its name, as a `String`, and the associated state as a `Symbol`.
 """
-function get_state_series(res::SimulationResults, ref::Tuple{String, Symbol}; dt = nothing)
-    return post_proc_state_series(res, ref, dt)
+function get_state_series(
+    res::SimulationResults,
+    ref::Tuple{String, Symbol};
+    dt = nothing,
+    unique_timestamps = true,
+)
+    return post_proc_state_series(res, ref, dt, unique_timestamps)
 end
 
 """
@@ -324,10 +354,16 @@ Function to obtain the voltage magnitude series out of the DAE Solution.
 - `res::SimulationResults` : Simulation Results object that contains the solution
 - `bus_number::Int` : Bus number identifier
 """
-function get_voltage_magnitude_series(res::SimulationResults, bus_number::Int; dt = nothing)
+function get_voltage_magnitude_series(
+    res::SimulationResults,
+    bus_number::Int;
+    dt = nothing,
+    unique_timestamps = true,
+)
     n_buses = get_bus_count(res)
     bus_ix = get(get_bus_lookup(res), bus_number, 0)
-    ts, V_R, V_I = post_proc_voltage_series(res.solution, bus_ix, n_buses, dt)
+    ts, V_R, V_I =
+        post_proc_voltage_series(res.solution, bus_ix, n_buses, dt, unique_timestamps)
     return ts, sqrt.(V_R .^ 2 .+ V_I .^ 2)
 end
 
@@ -344,10 +380,16 @@ Function to obtain the voltage angle series out of the DAE Solution.
 - `res::SimulationResults` : Simulation Results object that contains the solution
 - `bus_number::Int` : Bus number identifier
 """
-function get_voltage_angle_series(res::SimulationResults, bus_number::Int; dt = nothing)
+function get_voltage_angle_series(
+    res::SimulationResults,
+    bus_number::Int;
+    dt = nothing,
+    unique_timestamps = true,
+)
     n_buses = get_bus_count(res)
     bus_ix = get(get_bus_lookup(res), bus_number, 0)
-    ts, V_R, V_I = post_proc_voltage_series(res.solution, bus_ix, n_buses, dt)
+    ts, V_R, V_I =
+        post_proc_voltage_series(res.solution, bus_ix, n_buses, dt, unique_timestamps)
     return ts, atan.(V_I, V_R)
 end
 
@@ -364,8 +406,13 @@ Function to obtain the real current time series of a Dynamic Injection series ou
 - `res::SimulationResults` : Simulation Results object that contains the solution
 - `name::String` : Name to identify the specified device
 """
-function get_real_current_series(res::SimulationResults, name::String; dt = nothing)
-    return post_proc_real_current_series(res, name, dt)
+function get_real_current_series(
+    res::SimulationResults,
+    name::String;
+    dt = nothing,
+    unique_timestamps = true,
+)
+    return post_proc_real_current_series(res, name, dt, unique_timestamps)
 end
 
 """
@@ -381,8 +428,13 @@ Function to obtain the imaginary current time series of a Dynamic Injection seri
 - `res::SimulationResults` : Simulation Results object that contains the solution
 - `name::String` : Name to identify the specified device
 """
-function get_imaginary_current_series(res::SimulationResults, name::String; dt = nothing)
-    return post_proc_imaginary_current_series(res, name, dt)
+function get_imaginary_current_series(
+    res::SimulationResults,
+    name::String;
+    dt = nothing,
+    unique_timestamps = true,
+)
+    return post_proc_imaginary_current_series(res, name, dt, unique_timestamps)
 end
 
 """
@@ -398,8 +450,13 @@ Function to obtain the active power output time series of a Dynamic Injection se
 - `res::SimulationResults` : Simulation Results object that contains the solution
 - `name::String` : Name to identify the specified device
 """
-function get_activepower_series(res::SimulationResults, name::String; dt = nothing)
-    return post_proc_activepower_series(res, name, dt)
+function get_activepower_series(
+    res::SimulationResults,
+    name::String;
+    dt = nothing,
+    unique_timestamps = true,
+)
+    return post_proc_activepower_series(res, name, dt, unique_timestamps)
 end
 
 """
@@ -415,8 +472,13 @@ Function to obtain the reactive power output time series of a Dynamic Injection 
 - `res::SimulationResults` : Simulation Results object that contains the solution
 - `name::String` : Name to identify the specified device
 """
-function get_reactivepower_series(res::SimulationResults, name::String; dt = nothing)
-    return post_proc_reactivepower_series(res, name, dt)
+function get_reactivepower_series(
+    res::SimulationResults,
+    name::String;
+    dt = nothing,
+    unique_timestamps = true,
+)
+    return post_proc_reactivepower_series(res, name, dt, unique_timestamps)
 end
 
 """
@@ -432,8 +494,13 @@ Function to obtain the field current time series of a Dynamic Generator out of t
 - `res::SimulationResults` : Simulation Results object that contains the solution
 - `name::String` : Name to identify the specified device
 """
-function get_field_current_series(res::SimulationResults, name::String; dt = nothing)
-    return post_proc_field_current_series(res, name, dt)
+function get_field_current_series(
+    res::SimulationResults,
+    name::String;
+    dt = nothing,
+    unique_timestamps = true,
+)
+    return post_proc_field_current_series(res, name, dt, unique_timestamps)
 end
 
 """
@@ -449,8 +516,13 @@ Function to obtain the field voltage time series of a Dynamic Generator out of t
 - `res::SimulationResults` : Simulation Results object that contains the solution
 - `name::String` : Name to identify the specified device
 """
-function get_field_voltage_series(res::SimulationResults, name::String; dt = nothing)
-    return post_proc_field_voltage_series(res, name, dt)
+function get_field_voltage_series(
+    res::SimulationResults,
+    name::String;
+    dt = nothing,
+    unique_timestamps = true,
+)
+    return post_proc_field_voltage_series(res, name, dt, unique_timestamps)
 end
 
 """
@@ -466,8 +538,13 @@ Function to obtain the pss output time series of a Dynamic Generator out of the 
 - `res::SimulationResults` : Simulation Results object that contains the solution
 - `name::String` : Name to identify the specified device
 """
-function get_pss_output_series(res::SimulationResults, name::String; dt = nothing)
-    return post_proc_pss_output_series(res, name, dt)
+function get_pss_output_series(
+    res::SimulationResults,
+    name::String;
+    dt = nothing,
+    unique_timestamps = true,
+)
+    return post_proc_pss_output_series(res, name, dt, unique_timestamps)
 end
 
 """
@@ -483,8 +560,13 @@ Function to obtain the mechanical torque time series of the mechanical torque ou
 - `res::SimulationResults` : Simulation Results object that contains the solution
 - `name::String` : Name to identify the specified device
 """
-function get_mechanical_torque_series(res::SimulationResults, name::String; dt = nothing)
-    return post_proc_mechanical_torque_series(res, name, dt)
+function get_mechanical_torque_series(
+    res::SimulationResults,
+    name::String;
+    dt = nothing,
+    unique_timestamps = true,
+)
+    return post_proc_mechanical_torque_series(res, name, dt, unique_timestamps)
 end
 
 """
@@ -499,8 +581,13 @@ Function to obtain the real current flowing through the series element of a Bran
 - `res::SimulationResults` : Simulation Results object that contains the solution
 - `name::String` : Name to identify the specified line
 """
-function get_real_current_branch_flow(res::SimulationResults, name::String; dt = nothing)
-    ts, _, _, _, _, Ir, _ = post_proc_branch_series(res, name, dt)
+function get_real_current_branch_flow(
+    res::SimulationResults,
+    name::String;
+    dt = nothing,
+    unique_timestamps = true,
+)
+    ts, _, _, _, _, Ir, _ = post_proc_branch_series(res, name, dt, unique_timestamps)
     return ts, Ir
 end
 
@@ -520,8 +607,9 @@ function get_imaginary_current_branch_flow(
     res::SimulationResults,
     name::String;
     dt = nothing,
+    unique_timestamps = true,
 )
-    ts, _, _, _, _, _, Ii = post_proc_branch_series(res, name, dt)
+    ts, _, _, _, _, _, Ii = post_proc_branch_series(res, name, dt, unique_timestamps)
     return ts, Ii
 end
 
@@ -549,8 +637,10 @@ function get_activepower_branch_flow(
     name::String,
     location::Symbol;
     dt = nothing,
+    unique_timestamps = true,
 )
-    ts, V_R_from, V_I_from, V_R_to, V_I_to, Ir, Ii = post_proc_branch_series(res, name, dt)
+    ts, V_R_from, V_I_from, V_R_to, V_I_to, Ir, Ii =
+        post_proc_branch_series(res, name, dt, unique_timestamps)
     if location == :from
         return ts, V_R_from .* Ir + V_I_from .* Ii
     elseif location == :to
@@ -585,8 +675,10 @@ function get_reactivepower_branch_flow(
     name::String,
     location::Symbol;
     dt = nothing,
+    unique_timestamps = true,
 )
-    ts, V_R_from, V_I_from, V_R_to, V_I_to, Ir, Ii = post_proc_branch_series(res, name, dt)
+    ts, V_R_from, V_I_from, V_R_to, V_I_to, Ir, Ii =
+        post_proc_branch_series(res, name, dt, unique_timestamps)
     if location == :from
         return ts, V_I_from .* Ir - V_R_from .* Ii
     elseif location == :to
@@ -610,8 +702,13 @@ Function to obtain the frequency time series of a Dynamic Injection out of the D
 - `res::SimulationResults` : Simulation Results object that contains the solution
 - `name::String` : Name to identify the specified device
 """
-function get_frequency_series(res::SimulationResults, name::String; dt = nothing)
-    return post_proc_frequency_series(res, name, dt)
+function get_frequency_series(
+    res::SimulationResults,
+    name::String;
+    dt = nothing,
+    unique_timestamps = true,
+)
+    return post_proc_frequency_series(res, name, dt, unique_timestamps)
 end
 
 """

--- a/src/post_processing/post_proc_inverter.jl
+++ b/src/post_processing/post_proc_inverter.jl
@@ -9,6 +9,7 @@ function compute_output_current(
     V_R::Vector{Float64},
     V_I::Vector{Float64},
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 ) where {G <: PSY.DynamicInverter}
 
     #Obtain Data
@@ -30,6 +31,7 @@ function compute_output_current(
         res,
         dynamic_device,
         dt,
+        unique_timestamps,
     )
 end
 
@@ -44,6 +46,7 @@ function compute_field_current(
     V_R::Vector{Float64},
     V_I::Vector{Float64},
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 ) where {G <: PSY.DynamicInverter}
     @warn("Field current does not exist in inverters. Returning zeros.")
     return (nothing, zeros(length(V_R)))
@@ -58,9 +61,10 @@ function compute_field_voltage(
     res::SimulationResults,
     dynamic_device::G,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 ) where {G <: PSY.DynamicInverter}
     @warn("Field voltage does not exist in inverters. Returning zeros.")
-    _, state = _post_proc_state_series(res.solution, 1, dt)
+    _, state = _post_proc_state_series(res.solution, 1, dt, unique_timestamps)
     return (nothing, zeros(length(state)))
 end
 
@@ -73,9 +77,10 @@ function compute_mechanical_torque(
     res::SimulationResults,
     dynamic_device::G,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 ) where {G <: PSY.DynamicInverter}
     @warn("Mechanical torque is not used in inverters. Returning zeros.")
-    _, state = _post_proc_state_series(res.solution, 1, dt)
+    _, state = _post_proc_state_series(res.solution, 1, dt, unique_timestamps)
     return (nothing, zeros(length(state)))
 end
 
@@ -83,6 +88,7 @@ function compute_frequency(
     res::SimulationResults,
     dyn_device::G,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 ) where {G <: PSY.DynamicInverter}
     outer_control = PSY.get_outer_control(dyn_device)
     frequency_estimator = PSY.get_freq_estimator(dyn_device)
@@ -93,6 +99,7 @@ function compute_frequency(
         res,
         dyn_device,
         dt,
+        unique_timestamps,
     )
 end
 
@@ -107,8 +114,9 @@ function _frequency(
     res::SimulationResults,
     dynamic_device::G,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 ) where {F <: PSY.FrequencyEstimator, G <: PSY.DynamicInverter}
-    ts, ω = post_proc_state_series(res, (name, :ω_oc), dt)
+    ts, ω = post_proc_state_series(res, (name, :ω_oc), dt, unique_timestamps)
     return ts, ω
 end
 
@@ -123,10 +131,11 @@ function _frequency(
     res::SimulationResults,
     dynamic_device::G,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 ) where {F <: PSY.FrequencyEstimator, G <: PSY.DynamicInverter}
     P_ref = PSY.get_P_ref(PSY.get_active_power_control(outer_control))
     ω_ref = PSY.get_ω_ref(dynamic_device)
-    ts, p_oc = post_proc_state_series(res, (name, :p_oc), dt)
+    ts, p_oc = post_proc_state_series(res, (name, :p_oc), dt, unique_timestamps)
     Rp = PSY.get_Rp(outer_control.active_power_control)
     ω_oc = ω_ref .+ Rp .* (P_ref .- p_oc)
     return ts, ω_oc
@@ -146,6 +155,7 @@ function _frequency(
     res::SimulationResults,
     dynamic_device::G,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 ) where {F <: PSY.FrequencyEstimator, G <: PSY.DynamicInverter}
     p_ref = PSY.get_P_ref(PSY.get_active_power_control(outer_control))
     q_ref = PSY.get_Q_ref(PSY.get_reactive_power_control(outer_control))
@@ -153,10 +163,10 @@ function _frequency(
     k1 = PSY.get_k1(active_power_control)
     ψ = PSY.get_ψ(active_power_control)
     γ = ψ - pi / 2
-    ts, E_oc = post_proc_state_series(res, (name, :E_oc), dt)
-    _, p_elec_out = post_proc_activepower_series(res, name, dt)
-    _, q_elec_out = post_proc_reactivepower_series(res, name, dt)
-    ω_sys = _system_frequency_series(res, dt)
+    ts, E_oc = post_proc_state_series(res, (name, :E_oc), dt, unique_timestamps)
+    _, p_elec_out = post_proc_activepower_series(res, name, dt, unique_timestamps)
+    _, q_elec_out = post_proc_reactivepower_series(res, name, dt, unique_timestamps)
+    ω_sys = _system_frequency_series(res, dt, unique_timestamps)
     ω_oc =
         ω_sys .+
         (k1 ./ E_oc .^ 2) .*
@@ -175,11 +185,12 @@ function _frequency(
     res::SimulationResults,
     dynamic_device::G,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 ) where {G <: PSY.DynamicInverter}
     kp_pll = PSY.get_kp_pll(freq_estimator)
     ki_pll = PSY.get_ki_pll(freq_estimator)
-    ts, vpll_q = post_proc_state_series(res, (name, :vq_pll), dt)
-    _, ε_pll = post_proc_state_series(res, (name, :ε_pll), dt)
+    ts, vpll_q = post_proc_state_series(res, (name, :vq_pll), dt, unique_timestamps)
+    _, ε_pll = post_proc_state_series(res, (name, :ε_pll), dt, unique_timestamps)
     pi_output = [pi_block(x, y, kp_pll, ki_pll)[1] for (x, y) in zip(vpll_q, ε_pll)]
     ω_pll = pi_output .+ 1.0 #See Hug ISGT-EUROPE2018 eqn. 9
     return ts, ω_pll
@@ -196,12 +207,13 @@ function _frequency(
     res::SimulationResults,
     dynamic_device::G,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 ) where {G <: PSY.DynamicInverter}
     kp_pll = PSY.get_kp_pll(freq_estimator)
     ki_pll = PSY.get_ki_pll(freq_estimator)
-    ts, vpll_q = post_proc_state_series(res, (name, :vq_pll), dt)
-    _, vpll_d = post_proc_state_series(res, (name, :vd_pll), dt)
-    _, ε_pll = post_proc_state_series(res, (name, :ε_pll), dt)
+    ts, vpll_q = post_proc_state_series(res, (name, :vq_pll), dt, unique_timestamps)
+    _, vpll_d = post_proc_state_series(res, (name, :vd_pll), dt, unique_timestamps)
+    _, ε_pll = post_proc_state_series(res, (name, :ε_pll), dt, unique_timestamps)
     pi_output =
         [pi_block(x, y, kp_pll, ki_pll)[1] for (x, y) in zip(atan.(vpll_q, vpll_d), ε_pll)]
     ω_pll = pi_output .+ 1.0 #See Hug ISGT-EUROPE2018 eqn. 9
@@ -211,6 +223,7 @@ end
 function _system_frequency_series(
     res::SimulationResults,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
     if get_global_vars_update_pointers(res)[GLOBAL_VAR_SYS_FREQ_INDEX] == 0
         ω_sys = 1.0
@@ -219,7 +232,7 @@ function _system_frequency_series(
             get_global_index(res),
             get_global_vars_update_pointers(res)[GLOBAL_VAR_SYS_FREQ_INDEX],
         )
-        ω_sys = post_proc_state_series(res, ω_sys_state, dt)[2]
+        ω_sys = post_proc_state_series(res, ω_sys_state, dt, unique_timestamps)[2]
     end
     return ω_sys
 end
@@ -238,9 +251,10 @@ function _output_current(
     res::SimulationResults,
     dynamic_device::G,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 ) where {C <: PSY.Converter, G <: PSY.DynamicInverter}
-    ts, ir_filter = post_proc_state_series(res, (name, :ir_filter), dt)
-    ts, ii_filter = post_proc_state_series(res, (name, :ii_filter), dt)
+    ts, ir_filter = post_proc_state_series(res, (name, :ir_filter), dt, unique_timestamps)
+    ts, ii_filter = post_proc_state_series(res, (name, :ii_filter), dt, unique_timestamps)
 
     return ts, base_power_ratio * ir_filter, base_power_ratio * ii_filter
 end
@@ -259,6 +273,7 @@ function _output_current(
     res::SimulationResults,
     ::G,
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 ) where {G <: PSY.DynamicInverter}
 
     #Get Converter parameters
@@ -281,9 +296,9 @@ function _output_current(
     Iq_extra = max.(K_hv * (V_t .- Vo_lim), 0.0)
 
     #Compute current
-    ts, Ip = post_proc_state_series(res, (name, :Ip), dt)
-    _, Iq = post_proc_state_series(res, (name, :Iq), dt)
-    _, Vmeas = post_proc_state_series(res, (name, :Vmeas), dt)
+    ts, Ip = post_proc_state_series(res, (name, :Ip), dt, unique_timestamps)
+    _, Iq = post_proc_state_series(res, (name, :Iq), dt, unique_timestamps)
+    _, Vmeas = post_proc_state_series(res, (name, :Vmeas), dt, unique_timestamps)
     Ip_sat = Ip
     if Lvpl_sw == 1
         LVPL = get_LVPL_gain.(Vmeas, Zerox, Brkpt, Lvpl1)

--- a/src/post_processing/post_proc_loads.jl
+++ b/src/post_processing/post_proc_loads.jl
@@ -9,6 +9,7 @@ function compute_output_current(
     V_R::Vector{Float64},
     V_I::Vector{Float64},
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
     #Obtain Data
     sys = get_system(res)
@@ -29,10 +30,10 @@ function compute_output_current(
     v_ds = V_R
 
     # Read states
-    ts, ψ_qs = post_proc_state_series(res, (name, :ψ_qs), dt)
-    _, ψ_ds = post_proc_state_series(res, (name, :ψ_ds), dt)
-    _, ψ_qr = post_proc_state_series(res, (name, :ψ_qr), dt)
-    _, ψ_dr = post_proc_state_series(res, (name, :ψ_dr), dt)
+    ts, ψ_qs = post_proc_state_series(res, (name, :ψ_qs), dt, unique_timestamps)
+    _, ψ_ds = post_proc_state_series(res, (name, :ψ_ds), dt, unique_timestamps)
+    _, ψ_qr = post_proc_state_series(res, (name, :ψ_qr), dt, unique_timestamps)
+    _, ψ_dr = post_proc_state_series(res, (name, :ψ_dr), dt, unique_timestamps)
 
     #Additional Fluxes 
     ψ_mq = X_aq * (ψ_qs / X_ls + ψ_qr / X_lr) # (4.14-15) in Krause
@@ -59,6 +60,7 @@ function compute_output_current(
     V_R::Vector{Float64},
     V_I::Vector{Float64},
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
     #Obtain Data
     sys = get_system(res)
@@ -75,8 +77,8 @@ function compute_output_current(
     X_p = PSY.get_X_p(dynamic_device)
 
     # Read states
-    ts, ψ_qr = post_proc_state_series(res, (name, :ψ_qr), dt)
-    _, ψ_dr = post_proc_state_series(res, (name, :ψ_dr), dt)
+    ts, ψ_qr = post_proc_state_series(res, (name, :ψ_qr), dt, unique_timestamps)
+    _, ψ_dr = post_proc_state_series(res, (name, :ψ_dr), dt, unique_timestamps)
 
     # voltages in QD 
     v_qs = V_I
@@ -113,6 +115,7 @@ function compute_output_current(
     V_R::Vector{Float64},
     V_I::Vector{Float64},
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
     #TODO: We should dispatch this using the ZipLoad model that we have, but that would
     #      require to properly have access to it in the SimResults.
@@ -153,6 +156,7 @@ function compute_output_current(
     V_R::Vector{Float64},
     V_I::Vector{Float64},
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
     #TODO: We should dispatch this using the ZipLoad model that we have, but that would
     #      require to properly have access to it in the SimResults.
@@ -194,6 +198,7 @@ function compute_output_current(
     V_R::Vector{Float64},
     V_I::Vector{Float64},
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
     #TODO: We should dispatch this using the ZipLoad model that we have, but that would
     #      require to properly have access to it in the SimResults.

--- a/src/post_processing/post_proc_source.jl
+++ b/src/post_processing/post_proc_source.jl
@@ -6,6 +6,7 @@ function post_proc_source_voltage_current_series(
     res::SimulationResults,
     name::String,
     dt = nothing,
+    unique_timestamps = true,
 )
     system = get_system(res)
     bus_lookup = get_bus_lookup(res)
@@ -31,7 +32,8 @@ function post_proc_source_voltage_current_series(
 
     bus_ix = get(bus_lookup, PSY.get_number(PSY.get_bus(device)), -1)
 
-    ts, Vb_R, Vb_I = post_proc_voltage_series(solution, bus_ix, n_buses, dt)
+    ts, Vb_R, Vb_I =
+        post_proc_voltage_series(solution, bus_ix, n_buses, dt, unique_timestamps)
 
     I_R = R_th * (Vs_R .- Vb_R) / Z_sq + X_th * (Vs_I .- Vb_I) / Z_sq
     I_I = R_th * (Vs_I .- Vb_I) / Z_sq - X_th * (Vs_R .- Vb_R) / Z_sq
@@ -44,8 +46,14 @@ Function to obtain output real current for a source. It receives the simulation 
 the Source name and an optional argument of the time step of the results.
 
 """
-function get_source_real_current_series(res::SimulationResults, name::String, dt = nothing)
-    ts, _, _, I_R, _ = post_proc_source_voltage_current_series(res, name, dt)
+function get_source_real_current_series(
+    res::SimulationResults,
+    name::String,
+    dt = nothing,
+    unique_timestamps = true,
+)
+    ts, _, _, I_R, _ =
+        post_proc_source_voltage_current_series(res, name, dt, unique_timestamps)
     return ts, I_R
 end
 
@@ -58,8 +66,10 @@ function get_source_imaginary_current_series(
     res::SimulationResults,
     name::String,
     dt = nothing,
+    unique_timestamps = true,
 )
-    ts, _, _, _, I_I = post_proc_source_voltage_current_series(res, name, dt)
+    ts, _, _, _, I_I =
+        post_proc_source_voltage_current_series(res, name, dt, unique_timestamps)
     return ts, I_I
 end
 
@@ -74,10 +84,11 @@ function compute_output_current(
     V_R::Vector{Float64},
     V_I::Vector{Float64},
     dt::Union{Nothing, Float64, Vector{Float64}},
+    unique_timestamps::Bool,
 )
     name = PSY.get_name(dynamic_device)
-    ts, Vt_internal = post_proc_state_series(res, (name, :Vt), dt)
-    _, θt_internal = post_proc_state_series(res, (name, :θt), dt)
+    ts, Vt_internal = post_proc_state_series(res, (name, :Vt), dt, unique_timestamps)
+    _, θt_internal = post_proc_state_series(res, (name, :θt), dt, unique_timestamps)
 
     Vr_internal = Vt_internal .* cos.(θt_internal)
     Vi_internal = Vt_internal .* sin.(θt_internal)

--- a/test/test_case_OMIB.jl
+++ b/test/test_case_OMIB.jl
@@ -87,6 +87,9 @@ Ybus_change = NetworkSwitch(
         @test isa(power, Tuple{Vector{Float64}, Vector{Float64}})
         @test isa(rpower, Tuple{Vector{Float64}, Vector{Float64}})
 
+        series_repeat_timestamps =
+            get_state_series(results, ("generator-102-1", :δ); unique_timestamps = false)
+        @test length(δ) + 1 == length(series_repeat_timestamps[2])
     finally
         @info("removing test files")
         rm(path; force = true, recursive = true)


### PR DESCRIPTION
Default behavior (`unique_timestamps = true`) remains unchanged; repeated timestamps are filtered to match existing simulation tools.
This allows the user to keep repeated timestamps if desired. 