### PR TITLE
Correct typo in `configure_logging`

### DIFF
--- a/src/utils/logging.jl
+++ b/src/utils/logging.jl
@@ -25,7 +25,7 @@ close(logger)
 function configure_logging(;
     console_level = Logging.Error,
     file_level = Logging.Info,
-    filename = LOG_FILENAME,
+    filename = SIMULATION_LOG_FILENAME,
 )
     return IS.configure_logging(;
         console = true,


### PR DESCRIPTION
`LOG_FILENAME` appears to be undefined. Is `SIMULATION_LOG_FILENAME` the right constant to use instead?